### PR TITLE
Fix/card overflow

### DIFF
--- a/src/assets/css/nysds-site.css
+++ b/src/assets/css/nysds-site.css
@@ -343,7 +343,6 @@ ex-header__title {
 }
 
 .card__media {
-    aspect-ratio: 2 / 1;
     margin-bottom: var(--nys-space-100);
 }
 
@@ -380,8 +379,8 @@ ex-header__title {
 a.card {
     color: inherit;
     text-decoration: none;
-    aspect-ratio: 1 / 1;
-    max-width: 100%;;
+    max-width: 100%;
+    ;
 }
 
 a.card:hover .card__title,
@@ -404,7 +403,6 @@ a.card:focus {
 }
 
 .card__no-border .card__media {
-    aspect-ratio: 1.7 / 1;
     margin: var(--nys-space-200) 0;
     max-height: 10rem;
 }
@@ -443,7 +441,7 @@ a.card:focus {
 
 }
 
-li > .section-nav__list {
+li>.section-nav__list {
     border: none;
 }
 
@@ -670,20 +668,24 @@ li > .section-nav__list {
 .token-list__item {
     margin-bottom: var(--nys-space-600);
 }
+
 .token-list__name {
     font-size: var(--nys-font-size-xl);
     margin: 0;
     padding: 0;
 }
+
 .token-list__raw {
     color: var(--nys-color-neutral-500);
     font-size: var(--nys-font-size-xs);
 }
-.token-list__info > div {
+
+.token-list__info>div {
     padding: var(--nys-space-50) var(--nys-space-250);
     background-color: var(--nys-color-neutral-50);
     height: auto;
 }
+
 .token-list__var {
     font-size: var(--nys-font-size-xs);
     word-break: break-all;
@@ -691,13 +693,15 @@ li > .section-nav__list {
     white-space: pre-wrap;
     line-height: 1;
 }
+
 .token-list__swatch {
     position: relative;
     width: 100%;
-    max-width: calc( var(--nys-space-1200) * 2);
+    max-width: calc(var(--nys-space-1200) * 2);
     height: var(--nys-space-1200);
     border-radius: var(--nys-radius-md);
 }
+
 .token-list__text {
     font-size: var(--nys-font-size-sm);
     position: absolute;
@@ -710,6 +714,7 @@ li > .section-nav__list {
     justify-content: flex-start;
     flex-direction: column-reverse;
 }
+
 .token-list__text--value::before {
     content: '';
     display: inline-block;
@@ -718,14 +723,17 @@ li > .section-nav__list {
     border-radius: var(--nys-radius-round);
     background: currentColor;
 }
+
 .token-list__text--value {
     position: relative;
     cursor: pointer;
 }
+
 .token-list__text--value::after {
     content: attr(data-tooltip);
     position: absolute;
-    bottom: 120%; /* Adjust position */
+    bottom: 120%;
+    /* Adjust position */
     left: 50%;
     transform: translateX(-50%);
     background: rgba(0, 0, 0, 0.8);
@@ -741,17 +749,19 @@ li > .section-nav__list {
 }
 
 .token-list__text--value:hover::after {
-opacity: 1;
+    opacity: 1;
 }
-  
+
 /*** Code Previews Container ***/
 .code-preview-container {
     border: 1px solid var(--nys-color-neutral-200);
     border-radius: var(--nys-radius-md);
 }
+
 .code-preview {
     padding: var(--nys-space-200);
 }
+
 .code-preview-container details {
     border: none;
     background-color: var(--nys-color-theme-faint);
@@ -788,8 +798,10 @@ summary:hover {
 }
 
 .byline p {
-    max-width: 85%; /* Limit the width of the byline to align with NYSDS lockup */
+    max-width: 85%;
+    /* Limit the width of the byline to align with NYSDS lockup */
 }
+
 /* Align the logo lockup with the center of the homepage graphic */
 .nys-top-300 {
     margin-top: var(--nys-space-300);


### PR DESCRIPTION
The aspect ratio is set to 1/1 which works and renders as a square when the content is wide enough. In safari this ratio is always listened to which appears as an overflow when the screen becomes narrower. In chrome the ratio is ignored when the content is longer breaking the ratio and appearing as a longer card. 
 