### PR TITLE
Add Neutral Color Ramp

### DIFF
--- a/src/_data/tokens.json
+++ b/src/_data/tokens.json
@@ -73,6 +73,16 @@
     }
   },
   {
+    "name": "--nys-color-accent",
+    "displayname": "Color Accent",
+    "description": "Bold accent color for highlighting or emphasis. Use sparingly, especially in application contexts where it can be confused with warning or error colors.",
+    "type": "color",
+    "rawvalue": "#face00",
+    "recommendedtype": {
+      "--nys-color-text": "#1b1b1b"
+    }
+  },
+  {
     "name": "--nys-color-info",
     "displayname": "Color Info",
     "description": "Informational color for neutral messages.",
@@ -112,16 +122,6 @@
     "recommendedtype": {
       "--nys-color-text": "#1b1b1b",
       "--nys-color-link": "#004dd1"
-    }
-  },
-  {
-    "name": "--nys-color-accent",
-    "displayname": "Color Accent",
-    "description": "Bold accent color for highlighting or emphasis. Use sparingly, especially in application contexts where it can be confused with warning or error colors.",
-    "type": "color",
-    "rawvalue": "#face00",
-    "recommendedtype": {
-      "--nys-color-text": "#1b1b1b"
     }
   },
   {
@@ -204,8 +204,7 @@
     "type": "color",
     "rawvalue": "#d89191",
     "recommendedtype": {
-      "--nys-color-text": "#1b1b1b",
-      "--nys-color-link": "#004dd1"
+      "--nys-color-text": "#1b1b1b"
     }
   }, 
   {
@@ -370,6 +369,83 @@
     "rawvalue": "#f6f6f6"
   },
   {
+    "name": "--nys-color-neutral-900",
+    "displayname": "Color Neutral 900",
+    "description": "Darkest neutral color.",
+    "type": "color",
+    "rawvalue": "#1b1b1b"
+  },
+  {
+    "name": "--nys-color-neutral-800",
+    "displayname": "Color Neutral 800",
+    "description": "Very dark neutral.",
+    "type": "color",
+    "rawvalue": "#323435"
+  },
+  {
+    "name": "--nys-color-neutral-700",
+    "displayname": "Color Neutral 700",
+    "description": "Dark neutral.",
+    "type": "color",
+    "rawvalue": "#4a4d4f"
+  },
+  {
+    "name": "--nys-color-neutral-600",
+    "displayname": "Color Neutral 600",
+    "description": "Medium-dark neutral.",
+    "type": "color",
+    "rawvalue": "#62666a"
+  },
+  {
+    "name": "--nys-color-neutral-500",
+    "displayname": "Color Neutral 500",
+    "description": "Mid-range neutral.",
+    "type": "color",
+    "rawvalue": "#797c7f"
+  },
+  {
+    "name": "--nys-color-neutral-400",
+    "displayname": "Color Neutral 400",
+    "description": "Medium-light neutral.",
+    "type": "color",
+    "rawvalue": "#909395"
+  },
+  {
+    "name": "--nys-color-neutral-300",
+    "displayname": "Color Neutral 300",
+    "description": "Soft gray neutral.",
+    "type": "color",
+    "rawvalue": "#a7a9ab"
+  },
+  {
+    "name": "--nys-color-neutral-200",
+    "displayname": "Color Neutral 200",
+    "description": "Pale gray neutral.",
+    "type": "color",
+    "rawvalue": "#bec0c1"
+  },
+  {
+    "name": "--nys-color-neutral-100",
+    "displayname": "Color Neutral 100",
+    "description": "Very light gray neutral",
+    "type": "color",
+    "rawvalue": "#d0d0ce"
+  },
+  {
+    "name": "--nys-color-neutral-50",
+    "displayname": "Color Neutral 50",
+    "description": "Soft off-white neutral.",
+    "type": "color",
+    "rawvalue": "#ededed"
+  },
+  {
+    "name": "--nys-color-neutral-10",
+    "displayname": "Color Neutral 10",
+    "description": "Lightest visible neutral.",
+    "type": "color",
+    "rawvalue": "#f6f6f6"
+  },
+  {
     "name": "--nys-color-black-transparent-50",
     "displayname": "Color Black Transparent 50",
     "description": "A black transparent overlay to be used with light backgrounds.",
@@ -388,7 +464,7 @@
     "displayname": "Color Black Transparent 200",
     "description": "A black transparent overlay to be used with light backgrounds.",
     "type": "color",
-    "rawvalue": "hsla (0, 0%, 100%, 0)"
+    "rawvalue": "hsla(0, 0%, 100%, 0)"
   },
   {
     "name": "--nys-color-black-transparent-300",
@@ -458,7 +534,7 @@
     "displayname": "Color White Transparent 200",
     "description": "A white transparent overlay to be used with dark backgrounds.",
     "type": "color",
-    "rawvalue": "hsla (0, 0%, 100%, 0)"
+    "rawvalue": "hsla(0, 0%, 100%, 0)"
   },
   {
     "name": "--nys-color-white-transparent-300",

--- a/src/content/pages/foundations/tokens/index.njk
+++ b/src/content/pages/foundations/tokens/index.njk
@@ -18,7 +18,7 @@ navOrder: 40
         <div class="token-list__example nys-tablet:nys-grid-col-3">
           {% if token.type == "color" %}
             <div class="{% if "transparent" in token.name %}token-list__swatch--checkerboard{% endif %}">
-              <div class="token-list__swatch {% if 'transparent' not in token.name and token.rawvalue in ['#ffffff', '#bec0c1', '#ededed'] %} token-list__swatch--white-border{% endif %}" style="background-color: var({{ token.name }});">
+              <div class="token-list__swatch {% if ('black' not in token.name) and ('white' in token.name or token.rawvalue in ['#ffffff', '#bec0c1'] )%} token-list__swatch--white-border{% endif %}" style="background-color: var({{ token.name }});">
                 {% if token.recommendedtype %}
                   <div class="token-list__text">
                   {% for textColor, details in token.recommendedtype %}


### PR DESCRIPTION
## Summary
Add the neutral color token ramp missing from the [Figma Foundation file](https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu/%F0%9F%8E%A8-NYSDS---Foundations?node-id=772-1944&p=f&m=dev)

## Related Issues
Ticket https://github.com/ITS-HCD/nysds-site/issues/185 🎟️


