### PR TITLE
Revise missing options example from storybook to reference site and other doc fixes

### DIFF
--- a/src/content/components/alert.md
+++ b/src/content/components/alert.md
@@ -15,6 +15,7 @@ navOrder: 2
 Alert banners are designed to display critical information, updates, or warnings that require the user's attention.
 
 The `<nys-alert>` component is a banner-like component that appears at the top of a screen to prominently display important information, along with optional links. Alerts keep users informed of important and sometimes time-sensitive changes.
+
 {% endblock %}
 
 {% block example %}
@@ -132,6 +133,18 @@ The `<nys-alert>` component includes the following accessibility-focused feature
 
 {% block options %}
 
+### Theme
+
+Set the `type` property to customize the alert style (e.g. `type="info"`).
+
+{% set preview %}<nys-alert
+ type="info"
+ heading="Information status"
+ text="Adirondack peaks auctor Hudson River flows semper Statue of Liberty est.">
+</nys-alert>{% endset %}
+{% set code = preview %}
+{% include "partials/code-preview.njk" %}
+
 ### Custom text description
 
 Add descriptive content to your alert using the `text` prop or the our slot feature. 
@@ -197,17 +210,33 @@ You may find having just a heading without description as a good compact version
 </nys-alert>{% endset %}
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
+
+### Action Links
+
+Display `primaryAction` and `secondaryAction` as links using the `primaryLabel` and `secondaryLabel` for the link text. You must provide both an action label and a URL for each action to ensure proper functionality.
+
+{% set preview %}<nys-alert
+  type="emergency"
+  heading="Winter storm warning: Dec 10th, 2024."
+  text="A major snowfall is expected across the state of New York for the weekend of Dec 7th. Stay home if possible and use extreme caution when driving."
+  primaryAction="https://www.ny.gov/"
+  secondaryAction="https://www.ny.gov/"
+  primaryLabel="Weather Report"
+  secondaryLabel="Plowing Schedule"
+></nys-alert>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
 {% endblock %}
 
 {% block properties %}
 
 | Property          | Type                                                                              |
 |-------------------|-----------------------------------------------------------------------------------|
+| `id`              | String                                                                            |
 | `dismissible`     | boolean                                                                           |
 | `duration`        | integer                                                                           |
 | `heading`         | String                                                                            |
 | `icon`            | String (`<nys-icon name>`)                                                        |
-| `id`              | String                                                                            |
 | `primaryAction`   | URL                                                                               |
 | `primaryLabel`    | String                                                                            |
 | `secondaryAction` | URL                                                                               |

--- a/src/content/components/avatar.md
+++ b/src/content/components/avatar.md
@@ -97,7 +97,7 @@ When no image or initials are set, an icon will be shown. The default avatar sho
 
 ### Shapes
 
-To change the shape of the avatar, set the `shape` attribute. The default shape is **circle**, but you can also set it to **square** or **rounded**.
+To change the shape of the avatar, set the `shape` attribute. The default shape is **"circle"**, but you can also set it to **"square"** or **"rounded"**.
 
 {% set preview %}
 <nys-avatar label="User avatar" shape="circle"></nys-avatar>
@@ -108,7 +108,9 @@ To change the shape of the avatar, set the `shape` attribute. The default shape 
 
 ### Background Color
 
-You can change the background color of an Avatar. Note that images will naturally cover over the background color.
+You can change the background color of an Avatar. This attribute accepts any valid color value, including [design tokens](https://designsystem.ny.gov/foundations/tokens/), such as `color="var(--nys-color-theme)"`.
+
+**Note:** images will naturally cover over the background color.
 
 {% set preview %}
 <nys-avatar label="User avatar" color="purple"></nys-avatar>{% endset %}
@@ -121,9 +123,9 @@ You can change the background color of an Avatar. Note that images will naturall
 
 | Property   | Type                                     |
 |------------|------------------------------------------|
+| `id`       | String                                   |
 | `color`    | String (CSS HEX, CSS color name, or CSS) |
 | `icon`     | String (`<nys-icon name>`)               |
-| `id`       | String                                   |
 | `image`    | URL                                      |
 | `initials` | String (2 letters)                       |
 | `label`    | String                                   |

--- a/src/content/components/button.md
+++ b/src/content/components/button.md
@@ -163,7 +163,7 @@ Set the `target` prop of the `<nys-button>` to specify where to open the linked 
 - `_top`: Opens the link in the full body of the window.
 - `framename`: Opens the link in a named iframe.
 
-{% set preview %}<nys-button href="https://www.ny.gov/" id="button1" name="button1" label="Visit NY.gov"></nys-button>{% endset %}
+{% set preview %}<nys-button href="https://www.ny.gov/" target="_blank" id="button1" name="button1" label="Visit NY.gov"></nys-button>{% endset %}
 {% set code = preview %}
 {% include "partials/code-preview.njk" %}
 
@@ -191,14 +191,14 @@ Set the `inverted` when the button is on a dark background.
 
 | Property     | Type                                                               |
 |--------------|--------------------------------------------------------------------|
+| `id`         | String                                                             |
+| `name`       | String                                                             |
 | `disabled`   | boolean                                                            |
 | `form`       | String                                                             |
 | `fullWidth`  | boolean                                                            |
 | `href`       | String (URL)                                                       |                
-| `id`         | String                                                             |
 | `inverted`   | boolean                                                            |
 | `label`      | String                                                             |
-| `name`       | String                                                             |
 | `onClick`    | JS function                                                        |
 | `prefixIcon` | String (`<nys-icon name>`)                                         |
 | `size`       | `"sm"` \| `"md"` \| `"lg"`                                         |

--- a/src/content/components/checkbox.md
+++ b/src/content/components/checkbox.md
@@ -73,15 +73,15 @@ The `<nys-checkbox>` component includes the following accessibility-focused feat
 The `<nys-checkboxgroup>` component can be used to group multiple checkboxes so they function as a single form control. This is useful when you want to allow users to select multiple options from a list.
 
 {% set preview %}<nys-checkboxgroup label="Do you attest to the following:" description="By checking below you agree to our terms">
-<nys-checkbox label="I have read the terms and conditions." id="terms-conditions" name="terms" value="terms-conditions"></nys-checkbox>
-<nys-checkbox label="I agree to the NDA" id="legal" name="legal" value="legal"></nys-checkbox>
+  <nys-checkbox label="I have read the terms and conditions." id="terms-conditions" name="terms" value="terms-conditions"></nys-checkbox>
+  <nys-checkbox label="I agree to the NDA" id="legal" name="legal" value="legal"></nys-checkbox>
 </nys-checkboxgroup>{% endset %}
 {% set code = preview %}
 {% include "partials/code-preview.njk" %}
 
 ### Disabled
 
-{% set preview %}<nys-checkbox disabled label="I agree to the terms and conditions" description="This option is currently unavailable." name="earlyVoting" value="early-voting"></nys-checkbox>{% endset %}
+{% set preview %}<nys-checkbox disabled checked label="I agree to the terms and conditions" description="This option is currently unavailable." name="earlyVoting" value="early-voting"></nys-checkbox>{% endset %}
 {% set code = preview %}
 {% include "partials/code-preview.njk" %}
 
@@ -93,12 +93,12 @@ Set the size property of the `<nys-checkboxgroup>` to have all `<nys-checkbox>` 
 
 {% set preview %}
 <nys-checkboxgroup label="Select your favorite New York landmarks" description="Choose from the options below" size="sm">
-<nys-checkbox label="Adirondacks" name="landmarks" value="adirondacks" checked></nys-checkbox>
-<nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" checked></nys-checkbox>
-<nys-checkbox name="landmarks" value="catskills" label="Catskills" checked></nys-checkbox>
-<nys-checkbox name="landmarks" value="niagara-falls" label="Niagara Falls"></nys-checkbox>
-<nys-checkbox name="landmarks" value="coney-island" label="Coney Island"></nys-checkbox>
-<nys-checkbox label="Mount Greylock" description="This is disabled because it's not in New York." disabled></nys-checkbox>
+  <nys-checkbox label="Adirondacks" name="landmarks" value="adirondacks" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="catskills" label="Catskills" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="niagara-falls" label="Niagara Falls"></nys-checkbox>
+  <nys-checkbox name="landmarks" value="coney-island" label="Coney Island"></nys-checkbox>
+  <nys-checkbox label="Mount Greylock" description="This is disabled because it's not in New York." disabled></nys-checkbox>
 </nys-checkboxgroup>{% endset %}
 {% set code = preview %}
 {% include "partials/code-preview.njk" %}
@@ -111,12 +111,41 @@ The `tile` prop will change the styling of the checkbox to a tile. This is usefu
 
 {% set preview %}
 <nys-checkboxgroup label="Select your favorite New York landmarks" description="Choose from the options below" tile>
-<nys-checkbox label="Adirondacks" name="landmarks" value="adirondacks" checked></nys-checkbox>
-<nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" checked></nys-checkbox>
-<nys-checkbox name="landmarks" value="catskills" label="Catskills" checked></nys-checkbox>
-<nys-checkbox name="landmarks" value="niagara-falls" label="Niagara Falls"></nys-checkbox>
-<nys-checkbox name="landmarks" value="coney-island" label="Coney Island"></nys-checkbox>
-<nys-checkbox label="Mount Greylock" description="This is disabled because it's not in New York." disabled></nys-checkbox>
+  <nys-checkbox label="Adirondacks" name="landmarks" value="adirondacks" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="catskills" label="Catskills" checked></nys-checkbox>
+  <nys-checkbox name="landmarks" value="niagara-falls" label="Niagara Falls"></nys-checkbox>
+  <nys-checkbox name="landmarks" value="coney-island" label="Coney Island"></nys-checkbox>
+  <nys-checkbox label="Mount Greylock" description="This is disabled because it's not in New York." disabled></nys-checkbox>
+</nys-checkboxgroup>{% endset %}
+{% set code = preview %}
+{% include "partials/code-preview.njk" %}
+
+### Required
+
+Set `required` to make a checkbox or group of checkboxes mandatory. It can be applied to either `<nys-checkboxgroup>` (no need to add it to individual children) or directly to an individual `<nys-checkbox>`.
+
+{% set preview %}
+<nys-checkbox
+  label="Subscribe to NYS Government Updates"
+  description="Get notified via email about important updates and services."
+  id="subscribe-checkbox-disabled-checked"
+  name="subscribe"
+  value="email-updates"
+  required
+></nys-checkbox>{% endset %}
+{% set code = preview %}
+{% include "partials/code-preview.njk" %}
+
+### Optional
+
+Adding the `optional` prop will add an optional flag to the input.
+
+{% set preview %}
+<nys-checkboxgroup label="Select your favorite New York landmarks" description="Choose from the options below" optional>
+  <nys-checkbox label="Adirondacks" name="landmarks" value="adirondacks" ></nys-checkbox>
+  <nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes"></nys-checkbox>
+  <nys-checkbox name="landmarks" value="catskills" label="Catskills"></nys-checkbox>
 </nys-checkboxgroup>{% endset %}
 {% set code = preview %}
 {% include "partials/code-preview.njk" %}
@@ -129,9 +158,9 @@ Errors can be assigned to both `<nys-checkboxgroup>` and individual `<nys-checkb
 
 {% set preview %}
 <nys-checkboxgroup label="Select your favorite New York landmarks" description="Choose from the options below" showError errorMessage="You must select at least one option to continue.">
-<nys-checkbox label="Adirondacks" name="landmarks" value="adirondacks" ></nys-checkbox>
-<nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" ></nys-checkbox>
-<nys-checkbox name="landmarks" value="catskills" label="Catskills" ></nys-checkbox>
+  <nys-checkbox label="Adirondacks" name="landmarks" value="adirondacks" ></nys-checkbox>
+  <nys-checkbox name="landmarks" value="finger-lakes" label="Finger Lakes" ></nys-checkbox>
+  <nys-checkbox name="landmarks" value="catskills" label="Catskills" ></nys-checkbox>
 </nys-checkboxgroup>{% endset %}
 {% set code = preview %}
 {% include "partials/code-preview.njk" %}
@@ -152,19 +181,19 @@ When the description requires more complexity than a simple string, use the desc
 
 | Property       | Type             | Component                  |
 |----------------|------------------|----------------------------|
+| `id`           | String           | both                       |
+| `name`         | String           | both                       |
+| `label`        | String           | both                       |
+| `value`        | String           | only `<nys-checkbox>`      |
 | `checked`      | boolean          | only `<nys-checkbox>`      |
 | `description`  | String           | both                       |
 | `disabled`     | boolean          | both                       |
 | `errorMessage` | String           | both                       |
-| `id`           | String           | both                       |
-| `label`        | String           | both                       |
-| `name`         | String           | both                       |
 | `optional`     | boolean          | only `<nys-checkboxgroup>` |
 | `required`     | boolean          | both                       |
 | `showError`    | boolean          | both                       |
 | `size`         | `"sm"` \| `"md"` | both                       |
 | `tile`         | boolean          | both                       |
-| `value`        | String           | only `<nys-checkbox>`      |
 
 
 {% endblock %}

--- a/src/content/components/icon.md
+++ b/src/content/components/icon.md
@@ -12,7 +12,7 @@ navOrder: 8
 
 {% block longdescription %}
 
-An `<nys-icon>` is a visual symbol used to concisely convey meaning or action and can add to visual appearance. Icons are meant to enhance, not replace textual information. NYSDS includes a curated subset of the Google Material Symbols rounded icon set.
+The `<nys-icon>` is a visual symbol used to concisely convey meaning or action and can add to visual appearance. Icons are meant to enhance, not replace textual information. NYSDS includes a curated subset of the Google Material Symbols rounded icon set.
 {% endblock %}
 
 {% block example %}
@@ -227,19 +227,15 @@ Set an icon to flip horizontally, vertically, or in both directions by using the
 
 | Property | Type                                                                                                                                                   |
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `label`  | String                                                                                                                                                 |
 | `color`  | String (CSS HEX, CSS color name, or CSS variable)                                                                                                      |
 | `flip`   | `"horizontal"` \| `"vertical"` \| `"both"`                                                                                                             |
-| `label`  | String                                                                                                                                                 |
 | `name`   | String                                                                                                                                                 |
 | `rotate` | integer                                                                                                                                                |
 | `size`   | `"2xs"` \| `"xs"` \| `"sm"` \| `"md"` \| `"lg"` \| `"xl"` \| `"2xl"` \| `"3xl"` \| `"4xl"` \| `"12"` \| `"16"` \| `"24"` \| `"32"` \| `"48"` \| `"64"` |
 
 
 {% endblock %}
-[[TODO]]
-| Variable             | Description                 |
-|----------------------|-----------------------------|
-| `--nys-toggle-width` | Width of the toggle switch. |
 
 {% block cssvariables %}
 

--- a/src/content/components/radiobutton.md
+++ b/src/content/components/radiobutton.md
@@ -82,6 +82,24 @@ The `<nys-radiobutton>` component includes the following accessibility-focused f
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
 
+### Required
+Set `required` to `<radiogroup>` to make selecting an option mandatory.
+  {% set preview %}<nys-radiogroup label="What is your primary work location?" description="This is the location you use for your in office days." required>
+  <nys-radiobutton name="office" label="Albany" description="Upstate New York" value="albany"></nys-radiobutton>
+  <nys-radiobutton name="office" label="Manhattan" description="New York City" value="manhattan"></nys-radiobutton>
+</nys-radiogroup>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
+### Optional
+Adding the `optional` prop will add an optional flag to the input.
+  {% set preview %}<nys-radiogroup label="What is your primary work location?" description="This is the location you use for your in office days." optional>
+  <nys-radiobutton name="office" label="Albany" description="Upstate New York" value="albany"></nys-radiobutton>
+  <nys-radiobutton name="office" label="Manhattan" description="New York City" value="manhattan"></nys-radiobutton>
+</nys-radiogroup>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
 ### Size
 Set the `size` prop of the `<nys-radiogroup>` to have all `<nys-radiobutton>` be the same size. Our current sizes are:
 
@@ -142,20 +160,20 @@ Both `<nys-radiobutton>` and `<nys-radiogroup>` support the description slot.
 
 | Property       | Type             | Component                |
 |----------------|------------------|--------------------------|
-| `checked`      | boolean          | only `<nys-radiobutton>` |
-| `description`  | String           | both                     |
-| `disabled`     | boolean          | only `<nys-radiobutton>` |
-| `errorMessage` | String           | only `<nys-radiogroup>`  |
-| `form`         | String           | only `<nys-radiobutton>` |
 | `id`           | String           | both                     |
-| `label`        | String           | both                     |
 | `name`         | String           | both                     |
+| `label`        | String           | both                     |
+| `value`        | String           | only `<nys-radiobutton>` |
+| `checked`      | boolean          | only `<nys-radiobutton>` |
+| `disabled`     | boolean          | only `<nys-radiobutton>` |
+| `form`         | String           | only `<nys-radiobutton>` |
+| `description`  | String           | both                     |
+| `errorMessage` | String           | only `<nys-radiogroup>`  |
 | `optional`     | boolean          | only `<nys-radiogroup>`  |
 | `required`     | boolean          | only `<nys-radiogroup>`  |
 | `showError`    | boolean          | only `<nys-radiogroup>`  |
 | `size`         | `"sm"` \| `"md"` | only `<nys-radiogroup>`  |
 | `tile`         | boolean          | only `<nys-radiogroup>`  |
-| `value`        | String           | only `<nys-radiobutton>` |
 
 {% endblock %}
 

--- a/src/content/components/select.md
+++ b/src/content/components/select.md
@@ -72,6 +72,34 @@ The `<nys-select>` component includes the following accessibility-focused featur
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
 
+### Required
+Set `required` to `<nys-select>` to make selecting an option mandatory.
+
+{% set preview %}
+<nys-select label="Select your favorite borough" required>
+  <nys-option value="bronx" label="The Bronx"></nys-option>
+  <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+  <nys-option value="manhattan" label="Manhattan"></nys-option>
+  <nys-option value="staten_island" label="Staten Island"></nys-option>
+  <nys-option value="queens" label="Queens"></nys-option>  
+</nys-select>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
+### Optional
+Adding the `optional` prop will add an optional flag to the input.
+
+{% set preview %}
+<nys-select label="Select your favorite borough" optional>
+  <nys-option value="bronx" label="The Bronx"></nys-option>
+  <nys-option value="brooklyn" label="Brooklyn"></nys-option>
+  <nys-option value="manhattan" label="Manhattan"></nys-option>
+  <nys-option value="staten_island" label="Staten Island"></nys-option>
+  <nys-option value="queens" label="Queens"></nys-option>  
+</nys-select>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
 ### Width
 The following `width` options are available:
 
@@ -86,6 +114,21 @@ The following `width` options are available:
   <nys-option value="md" label="md"></nys-option>
   <nys-option value="lg" label="lg"></nys-option>
   <nys-option value="full" label="full"></nys-option>
+</nys-select>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
+### Slotted Description
+Add a description using the `description` prop for plain text, or use the description slot to include custom HTML for more flexibility.
+
+{% set preview %}
+<nys-select label="Select your favorite borough">
+  <label slot="description">This is a slot</label>
+  <nys-option value="bronx">The Bronx</nys-option>
+  <nys-option value="brooklyn">Brooklyn</nys-option>
+  <nys-option value="manhattan">Manhattan</nys-option>
+  <nys-option value="staten_island">Staten Island</nys-option>
+  <nys-option value="queens">Queens</nys-option>        
 </nys-select>{% endset %}
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
@@ -113,27 +156,23 @@ Setting `errorMessage` does not display the message without `showError` set to t
 
 | Property       | Type                                   | Component           |
 |----------------|----------------------------------------|---------------------|
+| `id`           | String                                 | only `<nys-select>` |
+| `name`         | String                                 | only `<nys-select>` |
+| `label`        | String                                 | both                |
 | `description`  | String                                 | only `<nys-select>` |
 | `disabled`     | boolean                                | both                |
 | `errorMessage` | String                                 | only `<nys-select>` |
-| `form`         | String                                 | only `<nys-select>` |
 | `hidden`       | boolean                                | only `<nys-option>` |
-| `id`           | String                                 | only `<nys-select>` |
-| `label`        | String                                 | both                |
-| `name`         | String                                 | only `<nys-select>` |
 | `optional`     | boolean                                | only `<nys-select>` |
 | `required`     | boolean                                | only `<nys-select>` |
 | `selected`     | boolean                                | only `<nys-option>` |
 | `showError`    | boolean                                | only `<nys-select>` |
+| `form`         | String                                 | only `<nys-select>` |
 | `value`        | String                                 | both                |
 | `width`        | `"sm"` \| `"md"` \| `"lg"` \| `"full"` | only `<nys-select>` |
 
 
 {% endblock %}
-[[TODO]]
-| Variable             | Description                 |
-|----------------------|-----------------------------|
-| `--nys-toggle-width` | Width of the toggle switch. |
 
 {% block cssvariables %}
 

--- a/src/content/components/textarea.md
+++ b/src/content/components/textarea.md
@@ -80,7 +80,7 @@ If an invalid option is assigned to `width`, it will be ignored and default to `
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
 
-### Resize
+### Resize Behavior
 By default a user can resize the `<nys-textarea>` vertically. If you want to disallow resizing altogether add `resize="none"`.
 
 **Note:** `resize` is not affected by setting `<nys-textarea>` to `disabled` or `readonly` as they are independent.
@@ -107,6 +107,11 @@ You can include a description to provide additional context for the user. This i
 </nys-textarea>{% endset %}
   {% include "partials/code-preview.njk" %}
 
+### Placeholder 
+  {% set preview %}<nys-textarea label="Placeholder" placeholder="this is a placeholder"></nys-textarea>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
 ### Disabled 
   {% set preview %}<nys-textarea label="Disabled textarea" disabled></nys-textarea>{% endset %}
   {% set code = preview %}
@@ -122,6 +127,16 @@ You can include a description to provide additional context for the user. This i
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
 
+### Required
+  {% set preview %}<nys-textarea required label="Required textarea"></nys-textarea>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
+### Optional
+  {% set preview %}<nys-textarea optional label="Optional textarea"></nys-textarea>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
 ### Error Message
 To display an error message, pass in the `showError` property to the `<nys-textarea>` component. Setting `errorMessage` does not display the message without `showError` set to true.
 
@@ -134,14 +149,14 @@ To display an error message, pass in the `showError` property to the `<nys-texta
 
 | Property       | Type                                   |
 |----------------|----------------------------------------|
+| `id`           | String                                 |
+| `name`         | String                                 |
+| `label`        | String                                 |
 | `description`  | String                                 |
 | `disabled`     | boolean                                |
 | `errorMessage` | String                                 |
 | `form`         | String                                 |
-| `id`           | String                                 |
-| `label`        | String                                 |
 | `maxLength`    | integer                                |
-| `name`         | String                                 |
 | `optional`     | boolean                                |
 | `placeholder`  | String                                 |
 | `readonly`     | boolean                                |
@@ -153,10 +168,6 @@ To display an error message, pass in the `showError` property to the `<nys-texta
 | `width`        | `"sm"` \| `"md"` \| `"lg"` \| `"full"` |
 
 {% endblock %}
-[[TODO]]
-| Variable             | Description                 |
-|----------------------|-----------------------------|
-| `--nys-toggle-width` | Width of the toggle switch. |
 
 {% block cssvariables %}
 

--- a/src/content/components/textinput.md
+++ b/src/content/components/textinput.md
@@ -81,7 +81,7 @@ Any other input defaults to `type="text"`
   {% include "partials/code-preview.njk" %}
 
 ### Placeholder
-  {% set preview %}<nys-textinput label="placeholder" placeholder="this is a placeholder"></nys-textinput>{% endset %}
+  {% set preview %}<nys-textinput label="Placeholder" placeholder="this is a placeholder"></nys-textinput>{% endset %}
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
 
@@ -115,14 +115,35 @@ Takes any valid regex value.
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
 
+### Required
+Set `required` to `<nys-textinput>` to make it mandatory.
+  {% set preview %}<nys-textinput name="myTextInput7" required label="label"></nys-textinput>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
+### Optional
+Adding the `optional` prop will add an optional flag to the input.
+  {% set preview %}<nys-textinput name="myTextInput7" optional label="label"></nys-textinput>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
+### Slotted Description
+Add a description using the `description` prop for plain text, or use the description slot to include custom HTML for more flexibility.
+Takes any valid regex value.
+  {% set preview %}<nys-textinput name="descriptionSlot" label="Label">
+  <label slot="description">Slot: description</label>
+</nys-textinput>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
 ### Slotted Button
-  Note: You can add a button to the input by adding a `slot="startButton"` or `slot="endButton"`. This will add a button to the left or right of the input respectively.
+  You can add a button to the input by adding a `slot="startButton"` or `slot="endButton"`. This will add a button to the left or right of the input respectively.
 
-  The button must be a `nys-button` component and one input should not add both a `startButton` and `endButton` to the same input.
+  **Note**: Use a `<nys-button>` for the slotted button. Do not use both `startButton` and `endButton` on the same input.
 
-  The slotted button will automatically be `size="sm"` and `variant="filled"` and support the disabled state of the input.
+  **Note**: The slotted button will automatically be `size="sm"` and `variant="filled"` and support the disabled state of the input.
 
-  When using a slotted button use either `<nys-textinput width="lg">` or `<nys-textinput width="full">` to ensure the input is wide enough for the user to see their input.
+  **Note**: Use `width="lg"` or `width="full"` on `<nys-textinput>` to give users enough space to enter text when a button is present.
 
   {% set preview %}<nys-textinput 
   name="searchInput"
@@ -154,16 +175,16 @@ Takes any valid regex value.
 
 | Property       | Type                                                                                    |
 |----------------|-----------------------------------------------------------------------------------------|
+| `id`           | String                                                                                  |
+| `name`         | String                                                                                  |
+| `label`        | String                                                                                  |
 | `description`  | String                                                                                  |
 | `disabled`     | boolean                                                                                 |
 | `errorMessage` | String                                                                                  |
 | `form`         | String                                                                                  |
-| `id`           | String                                                                                  |
-| `label`        | String                                                                                  |
 | `max`          | integer                                                                                 |
 | `maxlength`    | integer                                                                                 |
 | `min`          | integer                                                                                 |
-| `name`         | String                                                                                  |
 | `optional`     | boolean                                                                                 |
 | `pattern`      | REGEX                                                                                   |
 | `placeholder`  | String                                                                                  |

--- a/src/content/components/toggle.md
+++ b/src/content/components/toggle.md
@@ -73,6 +73,22 @@ The `<nys-toggle`> component includes the following accessibility-focused featur
 <nys-toggle size="md" label='Medium (size="md")' name="toggle-switch" value="access"></nys-toggle>{% endset %}
   {% include "partials/code-preview.njk" %}
 
+### Slotted Description
+Add help text to the toggle using the `label` and `description` props.
+Descriptions can be provided either through the `description` prop or via the `slot="description"`.
+
+**Note**: Use the prop for simple text. Use the slot when you need custom HTML, such as links or formatting.
+  {% set preview %}<nys-toggle label="Toggle Switch" name="toggle-switch" value="access">
+  <p slot="description">This slot is called 'description' (<a href="https://www.ny.gov/" target="_blank">learn more</a>)</p>
+</nys-toggle>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
+### Disabled Toggle
+  {% set preview %}<nys-toggle label="Disabled Unchecked" name="toggle-switch" value="access" disabled></nys-toggle>{% endset %}
+  {% set code = preview %}
+  {% include "partials/code-preview.njk" %}
+
 ### Disable Icon
   {% set preview %}<nys-toggle noIcon label="No Icon on the toggle" name="toggle-switch" value="access"></nys-toggle>{% endset %}
   {% set code = preview %}
@@ -84,13 +100,13 @@ The `<nys-toggle`> component includes the following accessibility-focused featur
 
 | Property      | Type             |
 |---------------|------------------|
+| `id`          | String           |
+| `label`       | String           |
+| `name`        | String           |
 | `checked`     | boolean          |
 | `description` | String           |
 | `disabled`    | boolean          |
 | `form`        | String           |
-| `id`          | String           |
-| `label`       | String           |
-| `name`        | String           |
 | `noIcon`      | boolean          |
 | `size`        | `"sm"` \| `"md"` |
 | `value`       | String           |

--- a/src/content/components/unav-header.md
+++ b/src/content/components/unav-header.md
@@ -59,14 +59,14 @@ The `<nys-unavheader>` component includes the following accessibility-focused fe
 
 {% block options %}
 
-### Search toggle
+### Search Off
   {% set preview %}
     <nys-unavheader hideSearch></nys-unavheader>
   {% endset %}
   {% set code = preview %}
   {% include "partials/code-preview.njk" %}
 
-### Translate toggle
+### Translate Off
   {% set preview %}
     <nys-unavheader hideTranslate></nys-unavheader>
   {% endset %}


### PR DESCRIPTION
## Summary
Align the Reference Site’s “Options” section with Storybook by adding missing examples and fixing related documentation.

## Related Ticket
Closes #192 🎟️