### PR TITLE
Doc: Add missing `nys-accordion` property info

### DIFF
--- a/src/content/components/accordion.md
+++ b/src/content/components/accordion.md
@@ -158,7 +158,7 @@ The `bordered` prop is available on `nys-accordion`. When set, all `nys-accordio
 | `id`              | String                 | both                      |
 | `heading`         | String                 | only `nys-accordionitem`  |
 | `expanded`        | Boolean                | only `nys-accordionitem`  |
-| `bordered`        | Boolean                | both                      |
+| `bordered`        | Boolean                | only `nys-accordion`      |
 | `singleSelect`    | Boolean                | only `nys-accordion`      |
 
 {% endblock %}


### PR DESCRIPTION
## Summary
The `nys-accordion` property section is missing some property info