### PR TITLE
Doc update for accordion on css override variables

### DIFF
--- a/src/_includes/layouts/component.njk
+++ b/src/_includes/layouts/component.njk
@@ -52,7 +52,7 @@
     </section>
     <br>
     <section>
-      <h2>CSS Variables</h2>
+      <h2>CSS Override Variables</h2>
       {%- block cssvariables %}{% endblock -%}
     </section>
     <br>

--- a/src/_includes/partials/css-vars.njk
+++ b/src/_includes/partials/css-vars.njk
@@ -28,7 +28,7 @@
     </table>
     {% else %}
     <p>
-        There are no existing CSS variables for this component. Explore existing <a href="#options">options</a>, or
+        There are no existing CSS override variables for this component. Explore existing <a href="#options">options</a>, or
         propose a
         new one with a
         <a href="https://github.com/ITS-HCD/nysds/discussions/categories/component-proposals">Component

--- a/src/content/components/accordion.md
+++ b/src/content/components/accordion.md
@@ -79,7 +79,7 @@ The `nys-accordion` and `nys-accordionitem` components are vertically stacked li
 The `nys-accordionitem` component includes the following accessibility-focused features:
 
   - Keyboard navigation (e.g. Tab to move between headers, Enter or Space to toggle).
-   -Headers are large enough to interact with easily (minimum 44x44px).
+  - Headers are large enough to interact with easily (minimum 44x44px).
 
 {% endblock %}
 
@@ -154,7 +154,7 @@ The `bordered` prop is available on `nys-accordion`. When set, all `nys-accordio
 {% block properties %}
 
 | Property          | Type                   | Component                 |
-|-------------------|----------------------------------------------------|
+|-------------------|------------------------|---------------------------|
 | `id`              | String                 | both                      |
 | `heading`         | String                 | only `nys-accordionitem`  |
 | `expanded`        | Boolean                | only `nys-accordionitem`  |
@@ -163,11 +163,30 @@ The `bordered` prop is available on `nys-accordion`. When set, all `nys-accordio
 
 {% endblock %}
 
-{% block cssvariables %}{% include "partials/css-vars.njk" %}{% endblock %}
+{% block cssvariables %}
+These CSS custom properties are exposed for developers to customize the visual appearance of the component <strong>when necessary</strong>, beyond the defaults provided by the NYS Design System. Set them on the component selector to override the default styles.
+
+{% set code %}
+nys-accordion {
+  --nys-accordion-header-background-color: #fff;
+  --nys-accordion-content-max-width: 100%;
+}{% endset %}
+{% set accordionLabel = "Example" %}
+{% set codeExpanded = true %}
+{% set codeLanguage = "css" %}
+{% include "partials/code-preview.njk" %}
+
+  {% set variables = [
+  { name: "--nys-accordion-header-background-color", description: "Background color of the accordion header."},
+  { name: "--nys-accordion-content-max-width", description: "Maximum readable width of the accordion content. Defaults to a readable character-based width (80ch) for accessibility."}
+]%}
+  {% include "partials/css-vars.njk" %}
+
+{% endblock %}
 
 {% block events %}
 
-The `<nys-accordionitem>` component emits **one** custom Javascript events:
+The `<nys-accordionitem>` component emits **one** custom Javascript event:
 
   1.  **`nys-accordionitem-toggle`** – Emitted when the accordion is clicked.
 

--- a/src/content/components/button.md
+++ b/src/content/components/button.md
@@ -230,11 +230,22 @@ Set the `inverted` when the button is on a dark background.
 | `suffixIcon`       | String (`<nys-icon name>`)                                         |
 | `target`           | `"_self"` \| `"_blank"` \| `"_parent"` \| `"_top"` \| `"framename"`|
 | `variant`          | `"filled"` \| `"outline"` \| `"ghost"` \| `"text"`                 |
-| `form`             | String \| `null`                                                  |
+| `form`             | String \| `null`                                                   |
 
 {% endblock %}
 
 {% block cssvariables %}
+These CSS custom properties are exposed for developers to customize the visual appearance of the component <strong>when necessary</strong>, beyond the defaults provided by the NYS Design System. Set them on the component selector to override the default styles.
+
+{% set code %}
+nys-button {
+  --nys-button-color: #ffffff;
+}
+{% endset %}
+{% set accordionLabel = "Example" %}
+{% set codeExpanded = true %}
+{% set codeLanguage = "css" %}
+{% include "partials/code-preview.njk" %}
 
   {% set variables = [
   { name: "--nys-button-color", description: "Text color of label"},


### PR DESCRIPTION
## Summary
For hotfix or Sprint 33

- Doc revisions for css variable exposures (e.g. `nys-accordion`)

## Screenshot

<img width="753" height="495" alt="Screenshot 2026-02-11 at 10 37 16 AM" src="https://github.com/user-attachments/assets/064f3711-2a07-474e-83e8-83c3703e0166" />
