### PR TITLE
Fix homepage typo: code-pairity → code parity

### DIFF
--- a/src/content/pages/index.njk
+++ b/src/content/pages/index.njk
@@ -41,7 +41,7 @@ heading_links: false
         </div>
         <div class="nys-grid-col-8" style="place-content: center;">
           <p class="nys-font-h2">For designers</p>
-          <p>Reusable design templates with code-pairity.</p>
+          <p>Reusable design templates with code parity.</p>
           <nys-button size="sm" label="Start designing" variant="outline" href="/get-started/designers/"></nys-button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fixes typo on homepage: "code-pairity" → "code parity" in the designers card

## Test plan
- [ ] Verify the homepage displays "code parity" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)