### PR TITLE
Docs fix grid ramp guide

### DIFF
--- a/src/content/updates/2026-05-14-release-1.18.0.md
+++ b/src/content/updates/2026-05-14-release-1.18.0.md
@@ -110,7 +110,7 @@ The `$grid-gaps` SCSS map now uses the standard NYSDS ramp. Update any old grid 
         <td><code>nys-grid-gap-200</code></td>
       </tr>
       <tr>
-        <td><code>nys-grid-gap-300</code></td>
+        <td><code>nys-grid-gap-lg</code></td>
         <td><nys-icon name="arrow_forward" size="4xl"></nys-icon></td>
         <td><code>nys-grid-gap-300</code></td>
       </tr>


### PR DESCRIPTION
Not sure how this happened but fixing it
### old: 
<img width="772" height="330" alt="image" src="https://github.com/user-attachments/assets/4f190143-03dc-4864-b1b7-354bdad8c209" />
### new: 
<img width="826" height="306" alt="image" src="https://github.com/user-attachments/assets/cebd7d34-5f42-430d-a0a0-bca6e33cd7d3" />
