### PR TITLE
Removes file extensions from A11y test+build page URLs

### DIFF
--- a/src/_includes/layouts/component-a11y-build.njk
+++ b/src/_includes/layouts/component-a11y-build.njk
@@ -5,7 +5,7 @@
         <p>
             Are you in the right place?
             If you are constrained to a third-party component library, see the
-            <a href="./accessibility-tests.html">{{ pattern }} Accessibility Checklist</a> and ensure that it passes.
+            <a href="./accessibility-tests/">{{ pattern }} Accessibility Checklist</a> and ensure that it passes.
             Otherwise, follow the guidance here to choose the best option for your project.
         </p>
     </section>

--- a/src/_includes/layouts/component-a11y-tests.njk
+++ b/src/_includes/layouts/component-a11y-tests.njk
@@ -10,7 +10,7 @@
         <h1>{{ title }}</h1>
         Any {{ pattern }} used in a New York State website should pass these tests and checklists.
         Also follow this acceptance criteria when building and testing a
-        <a href="./accessibility-build.html">custom {{ pattern }}</a>
+        <a href="./accessibility-build/">custom {{ pattern }}</a>
         and when evaluating third-party open source or licensed component libraries.
     </section>
     {% endblock -%}{# Introduction #}

--- a/src/_includes/layouts/component.njk
+++ b/src/_includes/layouts/component.njk
@@ -39,11 +39,11 @@
         </tr>
     </table>
     </nys-table>
-    
+
     <p>
         For comprehensive insight and guidance, please see
-        <a href="./accessibility-tests.html">Accessibility Checklists</a> and
-        <a href="./accessibility-build.html">Build Accessibly</a>.
+        <a href="./accessibility-tests/">Accessibility Checklists</a> and
+        <a href="./accessibility-build/">Build Accessibly</a>.
     </p>
     {% endif %}
     {%- block accessibility %}{% endblock -%}
@@ -54,7 +54,7 @@
         </mark>
         <span class="nys-font-h6">
             Additional accessibility test and build content is coming soon,
-            in a <a href="/components/accordion/accessibility-tests.html">new format</a>.
+            in a <a href="/components/accordion/accessibility-tests/">new format</a>.
         </span>
     </p>
     {% endif %}

--- a/src/_includes/partials/a11y-rely-checks.njk
+++ b/src/_includes/partials/a11y-rely-checks.njk
@@ -1,4 +1,4 @@
     <ins>
-        Rely on the required <a href="./accessibility-tests.html">checklists</a>
+        Rely on the required <a href="./accessibility-tests/">checklists</a>
         to ensure accessibility is maintained during integration.
     </ins>

--- a/src/content/components/accordion/a11y-build.njk
+++ b/src/content/components/accordion/a11y-build.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/accordion/accessibility-build.html
+permalink: /components/accordion/accessibility-build/
 title: Build Accessibly
 title_h1: Build an Accessible Accordion
 description: How to code an accessible accordion.

--- a/src/content/components/accordion/a11y-tests.njk
+++ b/src/content/components/accordion/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/accordion/accessibility-tests.html
+permalink: /components/accordion/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of an accordion.
 image: /assets/img/components/accordion.svg

--- a/src/content/components/accordion/a11y-tests.njk
+++ b/src/content/components/accordion/a11y-tests.njk
@@ -15,7 +15,7 @@ extra_css:
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In accordion.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/alert/a11y-tests.njk
+++ b/src/content/components/alert/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/alert/accessibility-tests.html
+permalink: /components/alert/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of an alert.
 image: /assets/img/components/alert.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/alert/a11y-tests.njk
+++ b/src/content/components/alert/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In alert.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/avatar/a11y-tests.njk
+++ b/src/content/components/avatar/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/avatar/accessibility-tests.html
+permalink: /components/avatar/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of an avatar.
 image: /assets/img/components/avatar.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/avatar/a11y-tests.njk
+++ b/src/content/components/avatar/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In avatar.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/backtotop/a11y-tests.njk
+++ b/src/content/components/backtotop/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In backtotop.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/backtotop/a11y-tests.njk
+++ b/src/content/components/backtotop/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/backtotop/accessibility-tests.html
+permalink: /components/backtotop/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a back-to-top.
 image: /assets/img/components/backtotop.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/badge/a11y-tests.njk
+++ b/src/content/components/badge/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/badge/accessibility-tests.html
+permalink: /components/badge/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a badge.
 image: /assets/img/components/badge.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/badge/a11y-tests.njk
+++ b/src/content/components/badge/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In button.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/breadcrumbs/a11y-build.njk
+++ b/src/content/components/breadcrumbs/a11y-build.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/breadcrumbs/accessibility-build.html
+permalink: /components/breadcrumbs/accessibility-build/
 title: Build Accessibly
 title_h1: Build an Accessible Breadcrumb
 description: How to code an accessible breadcrumb.

--- a/src/content/components/breadcrumbs/a11y-tests.njk
+++ b/src/content/components/breadcrumbs/a11y-tests.njk
@@ -15,7 +15,7 @@ extra_css:
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In breadcrumbs.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/breadcrumbs/a11y-tests.njk
+++ b/src/content/components/breadcrumbs/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/breadcrumbs/accessibility-tests.html
+permalink: /components/breadcrumbs/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a breadcrumbs.
 image: /assets/img/components/breadcrumbs.svg

--- a/src/content/components/button/a11y-tests.njk
+++ b/src/content/components/button/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/button/accessibility-tests.html
+permalink: /components/button/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a button.
 image: /assets/img/components/button.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/checkbox/a11y-tests.njk
+++ b/src/content/components/checkbox/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/checkbox/accessibility-tests.html
+permalink: /components/checkbox/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a checkbox.
 image: /assets/img/components/checkbox.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/checkbox/a11y-tests.njk
+++ b/src/content/components/checkbox/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In checkbox.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/combobox/a11y-tests.njk
+++ b/src/content/components/combobox/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In combobox.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/combobox/a11y-tests.njk
+++ b/src/content/components/combobox/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/combobox/accessibility-tests.html
+permalink: /components/combobox/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a combobox.
 image: /assets/img/components/combobox.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/datepicker/a11y-tests.njk
+++ b/src/content/components/datepicker/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/datepicker/accessibility-tests.html
+permalink: /components/datepicker/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a datepicker.
 image: /assets/img/components/datepicker.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/datepicker/a11y-tests.njk
+++ b/src/content/components/datepicker/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In datepicker.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/divider/a11y-tests.njk
+++ b/src/content/components/divider/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In divider.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/divider/a11y-tests.njk
+++ b/src/content/components/divider/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/divider/accessibility-tests.html
+permalink: /components/divider/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a divider.
 image: /assets/img/components/divider.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/dropdownmenu/a11y-tests.njk
+++ b/src/content/components/dropdownmenu/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/dropdownmenu/accessibility-tests.html
+permalink: /components/dropdownmenu/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a dropdown menu.
 image: /assets/img/components/dropdownmenu.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/dropdownmenu/a11y-tests.njk
+++ b/src/content/components/dropdownmenu/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In dropdownmenu.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/fileinput/a11y-tests.njk
+++ b/src/content/components/fileinput/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In fileinput.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/fileinput/a11y-tests.njk
+++ b/src/content/components/fileinput/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/fileinput/accessibility-tests.html
+permalink: /components/fileinput/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a file input.
 image: /assets/img/components/fileinput.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/globalfooter/a11y-tests.njk
+++ b/src/content/components/globalfooter/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/globalfooter/accessibility-tests.html
+permalink: /components/globalfooter/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a global footer.
 image: /assets/img/components/global-footer.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/globalfooter/a11y-tests.njk
+++ b/src/content/components/globalfooter/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In globalfooter.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/globalheader/a11y-tests.njk
+++ b/src/content/components/globalheader/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In globalheader.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/globalheader/a11y-tests.njk
+++ b/src/content/components/globalheader/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/globalheader/accessibility-tests.html
+permalink: /components/globalheader/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a global header.
 image: /assets/img/components/global-header.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/icon/a11y-tests.njk
+++ b/src/content/components/icon/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In icon.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/icon/a11y-tests.njk
+++ b/src/content/components/icon/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/icon/accessibility-tests.html
+permalink: /components/icon/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of an icon.
 image: /assets/img/components/icon.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/modal/a11y-tests.njk
+++ b/src/content/components/modal/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/modal/accessibility-tests.html
+permalink: /components/modal/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a modal.
 image: /assets/img/components/modal.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/modal/a11y-tests.njk
+++ b/src/content/components/modal/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In modal.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/pagination/a11y-tests.njk
+++ b/src/content/components/pagination/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In pagination.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/pagination/a11y-tests.njk
+++ b/src/content/components/pagination/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/pagination/accessibility-tests.html
+permalink: /components/pagination/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a pagination.
 image: /assets/img/components/pagination.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/radiobutton/a11y-tests.njk
+++ b/src/content/components/radiobutton/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/radiobutton/accessibility-tests.html
+permalink: /components/radiobutton/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a radio button.
 image: /assets/img/components/radiobutton.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/radiobutton/a11y-tests.njk
+++ b/src/content/components/radiobutton/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In radiobutton.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/select/a11y-tests.njk
+++ b/src/content/components/select/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/select/accessibility-tests.html
+permalink: /components/select/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a select.
 image: /assets/img/components/select.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/select/a11y-tests.njk
+++ b/src/content/components/select/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In select.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/skipnav/a11y-tests.njk
+++ b/src/content/components/skipnav/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In skipnav.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/skipnav/a11y-tests.njk
+++ b/src/content/components/skipnav/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/skipnav/accessibility-tests.html
+permalink: /components/skipnav/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a skip navigation.
 image: /assets/img/components/skipnav.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/stepper/a11y-tests.njk
+++ b/src/content/components/stepper/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/stepper/accessibility-tests.html
+permalink: /components/stepper/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a stepper.
 image: /assets/img/components/stepper.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/stepper/a11y-tests.njk
+++ b/src/content/components/stepper/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In stepper.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/tab/a11y-build.njk
+++ b/src/content/components/tab/a11y-build.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/tab/accessibility-build.html
+permalink: /components/tab/accessibility-build/
 title: Build Accessibly
 title_h1: Build an Accessible Tablist
 description: How to code an accessible tab.

--- a/src/content/components/tab/a11y-tests.njk
+++ b/src/content/components/tab/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/tab/accessibility-tests.html
+permalink: /components/tab/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a tab.
 image: /assets/img/components/tab.svg

--- a/src/content/components/tab/a11y-tests.njk
+++ b/src/content/components/tab/a11y-tests.njk
@@ -15,7 +15,7 @@ extra_css:
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In tab.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/table/a11y-tests.njk
+++ b/src/content/components/table/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/table/accessibility-tests.html
+permalink: /components/table/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a table.
 image: /assets/img/components/table.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/table/a11y-tests.njk
+++ b/src/content/components/table/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In table.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/textarea/a11y-tests.njk
+++ b/src/content/components/textarea/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/textarea/accessibility-tests.html
+permalink: /components/textarea/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a text area.
 image: /assets/img/components/textarea.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/textarea/a11y-tests.njk
+++ b/src/content/components/textarea/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In textarea.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/textinput/a11y-tests.njk
+++ b/src/content/components/textinput/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In textinput.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/textinput/a11y-tests.njk
+++ b/src/content/components/textinput/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/textinput/accessibility-tests.html
+permalink: /components/textinput/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a text input.
 image: /assets/img/components/textinput.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/toggle/a11y-tests.njk
+++ b/src/content/components/toggle/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In toggle.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/toggle/a11y-tests.njk
+++ b/src/content/components/toggle/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/toggle/accessibility-tests.html
+permalink: /components/toggle/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a toggle.
 image: /assets/img/components/toggle.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/tooltip/a11y-tests.njk
+++ b/src/content/components/tooltip/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In tooltip.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/tooltip/a11y-tests.njk
+++ b/src/content/components/tooltip/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/tooltip/accessibility-tests.html
+permalink: /components/tooltip/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a tooltip.
 image: /assets/img/components/tooltip.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/unavfooter/a11y-tests.njk
+++ b/src/content/components/unavfooter/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/unav-footer/accessibility-tests.html
+permalink: /components/unav-footer/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a universal navigation footer.
 image: /assets/img/components/unav-footer.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/unavfooter/a11y-tests.njk
+++ b/src/content/components/unavfooter/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In unavfooter.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/unavheader/a11y-tests.njk
+++ b/src/content/components/unavheader/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In unavheader.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/unavheader/a11y-tests.njk
+++ b/src/content/components/unavheader/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/unav-header/accessibility-tests.html
+permalink: /components/unav-header/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a universal navigation header.
 image: /assets/img/components/unav-header.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard

--- a/src/content/components/video/a11y-tests.njk
+++ b/src/content/components/video/a11y-tests.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#
-  In a11y-tests.11tydata.json5:
+  In video.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
 
   Members that may be commented are exactly these:

--- a/src/content/components/video/a11y-tests.njk
+++ b/src/content/components/video/a11y-tests.njk
@@ -1,5 +1,5 @@
 ---
-permalink: /components/video/accessibility-tests.html
+permalink: /components/video/accessibility-tests/
 title: Accessibility Checklist
 description: How to test the accessibility of a video player.
 image: /assets/img/components/videoplayer.svg
@@ -17,7 +17,7 @@ eleventyExcludeFromCollections: true
 {#
   In a11y-tests.11tydata.json5:
   Comment top-level members to determine which njk blocks will render.
-  
+
   Members that may be commented are exactly these:
   disabilities
   keyboard


### PR DESCRIPTION
Results in:

- /components/accordion/accessibility-tests
- /components/accordion/accessibility-build
- /components/breadcrumbs/accessibility-tests
- /components/breadcrumbs/accessibility-build
- /components/tab/accessibility-tests
- /components/tab/accessibility-build

Also updates comments per previously changed data file names.

Closes #473 