### PR TITLE
fix(a11y): add aria-label to card links

### DIFF
--- a/src/_includes/partials/a11y-contact-points.njk
+++ b/src/_includes/partials/a11y-contact-points.njk
@@ -1,5 +1,5 @@
 <section class="contact-points">
-    <a class="card card--horizontal" href="https://teams.microsoft.com/l/team/19%3AsOgJ0qBW2ZBGB9h8LxC37mmdQJKwOfLdAmwsOEDD5cY1%40thread.tacv2/conversations?groupId=e9810b17-e32f-499d-a5b0-192e4adcdce3&tenantId=f46cb8ea-7900-4d10-8ceb-80e8c1c81ee7">
+    <a class="card card--horizontal" href="https://teams.microsoft.com/l/team/19%3AsOgJ0qBW2ZBGB9h8LxC37mmdQJKwOfLdAmwsOEDD5cY1%40thread.tacv2/conversations?groupId=e9810b17-e32f-499d-a5b0-192e4adcdce3&tenantId=f46cb8ea-7900-4d10-8ceb-80e8c1c81ee7" aria-label="NYS Digital Accessibility MS Teams channel">
         <div class="card__inner">
             <div class="card__media card__media--thin">
                 <img src="/assets/img/teams-channel.svg" />
@@ -16,7 +16,7 @@
             </div>
         </div>
     </a>
-    <a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds/issues">
+    <a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds/issues" aria-label="Report a bug on GitHub">
         <div class="card__inner">
             <div class="card__media card__media--thin">
                 <img src="/assets/img/report-bug.svg" />

--- a/src/content/pages/about/contribute.md
+++ b/src/content/pages/about/contribute.md
@@ -23,7 +23,7 @@ When you submit a component request, we ask questions like:
 
 New proposals are announced in the design system teams channel. Once a proposal is accepted, the design system team will go through a UX design review and accessibility review, development, and finally testing. When that's done, it will be released to the reference site and our Figma libraries.
 
-<a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds/discussions">
+<a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds/discussions" aria-label="Propose a component">
     <div class="card__inner">
         <div class="card__media card__media--thin">
             <img src="/assets/img/propose-a-component.svg" />
@@ -44,7 +44,7 @@ New proposals are announced in the design system teams channel. Once a proposal 
 ## Found a Bug?
 If you find something that's not working, our design system team uses GitHub issues to track bugs, accessibility problems, or technical errors. We welcome feedback from all, but we do prioritize the needs of New York State government applications and sites.
 
-<a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds/issues">
+<a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds/issues" aria-label="Report a bug on GitHub">
     <div class="card__inner">
         <div class="card__media card__media--thin">
             <img src="/assets/img/report-bug.svg" />
@@ -67,7 +67,7 @@ You can join us on Microsoft Teams. If you work for New York State, you can join
 
 Every two weeks, our team hosts a design system office hours event on our team's channel. It's an informal online chat with our designers and engineers to troubleshoot together, ask about best practices, or see what's coming next.
 
-<a class="card card--horizontal" href="https://teams.microsoft.com/l/team/19%3Al5Zo00jgzpzTb5ACeXQQVatofIuRI-C0ThuQXbndb9U1%40thread.tacv2/conversations?groupId=40dc9e8f-13b9-4301-8cb7-db5c2b21c9fa&tenantId=f46cb8ea-7900-4d10-8ceb-80e8c1c81ee7">
+<a class="card card--horizontal" href="https://teams.microsoft.com/l/team/19%3Al5Zo00jgzpzTb5ACeXQQVatofIuRI-C0ThuQXbndb9U1%40thread.tacv2/conversations?groupId=40dc9e8f-13b9-4301-8cb7-db5c2b21c9fa&tenantId=f46cb8ea-7900-4d10-8ceb-80e8c1c81ee7" aria-label="NYS Design System Teams channel">
     <div class="card__inner">
         <div class="card__media card__media--thin">
             <img src="/assets/img/teams-channel.svg" />

--- a/src/content/pages/components/index.md
+++ b/src/content/pages/components/index.md
@@ -22,7 +22,7 @@ navOrder: -1
   {# Prevent child pages from rendering a card: child pages have a `parent` variable; component pages do NOT #}
   {% if post.data.parent is not defined %}
   <div class="nys-mobile-lg:nys-grid-col-6 nys-tablet:nys-grid-col-4 nys-desktop:nys-grid-col-4 nys-display-flex">
-    <a class="card nys-flex-fill" href="{{ post.url | url }}" title="{{ post.data.title }} Component">
+    <a class="card nys-flex-fill" href="{{ post.url | url }}" aria-label="{{ post.data.title }} Component">
       <div class="card__inner">
         <div class="card__media">{% if post.data.image %}
           <img src="{{ post.data.image | url }}" alt="{{ post.data.image_alt }}"></div>{% else %}

--- a/src/content/pages/foundations/accessibility/developers.md
+++ b/src/content/pages/foundations/accessibility/developers.md
@@ -109,7 +109,7 @@ When content changes without a full page reload:
 
 <div class="nys-grid-row">
   <div class="nys-grid-col-12">
-    <a class="card card--horizontal" href="https://on.ny.gov/a11yteam" target="_blank" rel="noopener">
+    <a class="card card--horizontal" href="https://on.ny.gov/a11yteam" target="_blank" rel="noopener" aria-label="Join ITS Accessibility Community">
       <div class="card__inner">
         <div class="card__media card__media--thin">
           <img src="/assets/img/teams-channel.svg" alt="" role="presentation" />
@@ -126,7 +126,7 @@ When content changes without a full page reload:
 
 <div class="nys-grid-row nys-grid-gap-300">
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-4 nys-display-flex">
-    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/Get-started.aspx?csf=1&web=1&share=IQB9OPiWlWK1QKiLwKnt_SlnAVxD3SO_eebbKlc69RlRYqc&e=vC8jYt">
+    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/Get-started.aspx?csf=1&web=1&share=IQB9OPiWlWK1QKiLwKnt_SlnAVxD3SO_eebbKlc69RlRYqc&e=vC8jYt" aria-label="Get started, by role">
       <div class="card__inner">
         <div class="card__category nys-margin-b-200"><nys-badge label="For NYS Staff" intent="neutral" size="sm" prefixIcon="lock_filled"></nys-badge></div>
         <div class="card__title">Get started, by role</div>
@@ -135,7 +135,7 @@ When content changes without a full page reload:
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-4 nys-display-flex">
-    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/t/its.365.DigitalAccessibility/IQBIx-MmHr1GQ4uxf38xsCJ6AeLh-P7wopABIBERADnNM6o?e=hmbMw1">
+    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/t/its.365.DigitalAccessibility/IQBIx-MmHr1GQ4uxf38xsCJ6AeLh-P7wopABIBERADnNM6o?e=hmbMw1" aria-label="Tools and Guides">
       <div class="card__inner">
         <div class="card__category nys-margin-b-200"><nys-badge label="For NYS Staff" intent="neutral" size="sm" prefixIcon="lock_filled"></nys-badge></div>
         <div class="card__title">Tools & Guides</div>
@@ -144,7 +144,7 @@ When content changes without a full page reload:
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-4 nys-display-flex">
-    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/POUR%20-%202%20-%20Perceivable.aspx?csf=1&web=1&share=IQAB9ZZ94vMPRoUR8ylezZ-mAYgCg3vubPaZJHvFk_f2KfM&e=c0pJHD">
+    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/POUR%20-%202%20-%20Perceivable.aspx?csf=1&web=1&share=IQAB9ZZ94vMPRoUR8ylezZ-mAYgCg3vubPaZJHvFk_f2KfM&e=c0pJHD" aria-label="Understand WCAG">
       <div class="card__inner">
         <div class="card__category nys-margin-b-200"><nys-badge label="For NYS Staff" intent="neutral" size="sm" prefixIcon="lock_filled"></nys-badge></div>
         <div class="card__title">Understand WCAG</div>

--- a/src/content/pages/foundations/accessibility/index.md
+++ b/src/content/pages/foundations/accessibility/index.md
@@ -181,7 +181,7 @@ navOrder: 2
 
 <div class="nys-grid-row nys-grid-gap-300">
   <div class="nys-grid-col-12">
-    <a class="card card--horizontal" href="/foundations/accessibility/developers/">
+    <a class="card card--horizontal" href="/foundations/accessibility/developers/" aria-label="Accessibility for Developers">
       <div class="card__inner">
         <div class="card__media card__media--thin">
           <img src="/assets/img/icon-code.svg" alt="" role="presentation" />
@@ -194,7 +194,7 @@ navOrder: 2
     </a>
   </div>
   <div class="nys-grid-col-12">
-    <a class="card card--horizontal" href="/foundations/accessibility/content/">
+    <a class="card card--horizontal" href="/foundations/accessibility/content/" aria-label="Accessibility for Content Creators">
       <div class="card__inner">
         <div class="card__media card__media--thin">
           <img src="/assets/img/icon-people.svg" alt="" role="presentation" />
@@ -207,7 +207,7 @@ navOrder: 2
     </a>
   </div>
   <div class="nys-grid-col-12">
-    <a class="card card--horizontal" href="/foundations/accessibility/leadership/">
+    <a class="card card--horizontal" href="/foundations/accessibility/leadership/" aria-label="Accessibility for Leadership">
       <div class="card__inner">
         <div class="card__media card__media--thin">
           <img src="/assets/img/icon-edit.svg" alt="" role="presentation" />
@@ -246,7 +246,7 @@ navOrder: 2
 
 <div class="nys-grid-row">
   <div class="nys-grid-col-12">
-    <a class="card card--horizontal" href="https://on.ny.gov/a11yteam" target="_blank" rel="noopener">
+    <a class="card card--horizontal" href="https://on.ny.gov/a11yteam" target="_blank" rel="noopener" aria-label="Join ITS Accessibility Community">
       <div class="card__inner">
         <div class="card__media card__media--thin">
           <img src="/assets/img/teams-channel.svg" alt="" role="presentation" />
@@ -263,7 +263,7 @@ navOrder: 2
 
 <div class="nys-grid-row nys-grid-gap-300">
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-4 nys-display-flex">
-    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/Get-started.aspx?csf=1&web=1&share=IQB9OPiWlWK1QKiLwKnt_SlnAVxD3SO_eebbKlc69RlRYqc&e=vC8jYt">
+    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/Get-started.aspx?csf=1&web=1&share=IQB9OPiWlWK1QKiLwKnt_SlnAVxD3SO_eebbKlc69RlRYqc&e=vC8jYt" aria-label="Get started, by role">
       <div class="card__inner">
         <div class="card__category"><nys-badge label="For NYS Staff" intent="neutral" size="sm" prefixIcon="lock_filled"></nys-badge></div>
         <div class="card__title">Get started, by role</div>
@@ -272,7 +272,7 @@ navOrder: 2
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-4 nys-display-flex">
-    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/t/its.365.DigitalAccessibility/IQBIx-MmHr1GQ4uxf38xsCJ6AeLh-P7wopABIBERADnNM6o?e=hmbMw1">
+    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/t/its.365.DigitalAccessibility/IQBIx-MmHr1GQ4uxf38xsCJ6AeLh-P7wopABIBERADnNM6o?e=hmbMw1" aria-label="Tools and Guides">
       <div class="card__inner">
         <div class="card__category"><nys-badge label="For NYS Staff" intent="neutral" size="sm" prefixIcon="lock_filled"></nys-badge></div>
         <div class="card__title">Tools & Guides</div>
@@ -281,7 +281,7 @@ navOrder: 2
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-4 nys-display-flex">
-    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/POUR%20-%202%20-%20Perceivable.aspx?csf=1&web=1&share=IQAB9ZZ94vMPRoUR8ylezZ-mAYgCg3vubPaZJHvFk_f2KfM&e=c0pJHD">
+    <a class="card nys-flex-fill" href="https://nysemail.sharepoint.com/:u:/r/teams/its.365.DigitalAccessibility/SitePages/POUR%20-%202%20-%20Perceivable.aspx?csf=1&web=1&share=IQAB9ZZ94vMPRoUR8ylezZ-mAYgCg3vubPaZJHvFk_f2KfM&e=c0pJHD" aria-label="Understand WCAG">
       <div class="card__inner">
         <div class="card__category"><nys-badge label="For NYS Staff" intent="neutral" size="sm" prefixIcon="lock_filled"></nys-badge></div>
         <div class="card__title">Understand WCAG</div>

--- a/src/content/pages/foundations/index.md
+++ b/src/content/pages/foundations/index.md
@@ -21,7 +21,7 @@ How the design system is built — the token layers, styling framework, theming 
 
 <div class="nys-grid-row nys-grid-gap-300">
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/accessibility/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/accessibility/" aria-label="Accessibility">
       <div class="card__inner">
         <div class="card__title">Accessibility</div>
         <div class="card__desc">How the design system supports WCAG 2.2 AA compliance, with guidance for developers, content creators, and leadership.</div>
@@ -29,7 +29,7 @@ How the design system is built — the token layers, styling framework, theming 
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/styles/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/styles/" aria-label="Styles Framework">
       <div class="card__inner">
         <div class="card__title">Styles Framework</div>
         <div class="card__desc">The <code>@nysds/styles</code> CSS package — design tokens as custom properties, a CSS reset, typography classes, and layout utilities.</div>
@@ -37,7 +37,7 @@ How the design system is built — the token layers, styling framework, theming 
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/themes/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/themes/" aria-label="Agency Themes">
       <div class="card__inner">
         <div class="card__title">Agency Themes</div>
         <div class="card__desc">Apply agency-specific color palettes with a single attribute — build once, switch themes, and every component updates automatically.</div>
@@ -45,7 +45,7 @@ How the design system is built — the token layers, styling framework, theming 
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/tokens/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/tokens/" aria-label="Design Tokens">
       <div class="card__inner">
         <div class="card__title">Design Tokens</div>
         <div class="card__desc">The shared language of colors, spacing, and typography values — how primitive, semantic, and theme tokens connect design decisions to code.</div>
@@ -53,7 +53,7 @@ How the design system is built — the token layers, styling framework, theming 
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/components/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/components/" aria-label="How Components Work">
       <div class="card__inner">
         <div class="card__title">How Components Work</div>
         <div class="card__desc">Web components, shadow DOM, slots, CSS custom properties, and the patterns you need to use NYSDS components effectively.</div>
@@ -68,7 +68,7 @@ Practical references for building interfaces with the design system — typograp
 
 <div class="nys-grid-row nys-grid-gap-300">
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/design/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/design/" aria-label="Design">
       <div class="card__inner">
         <div class="card__title">Design</div>
         <div class="card__desc">Where the design system fits in the broader UX process — from strategy and scope to the interface layer.</div>
@@ -76,7 +76,7 @@ Practical references for building interfaces with the design system — typograp
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/typography/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/typography/" aria-label="Typography">
       <div class="card__inner">
         <div class="card__title">Typography</div>
         <div class="card__desc">Core typefaces, typography tokens, font installation, and utility classes for consistent, accessible type across your application.</div>
@@ -84,7 +84,7 @@ Practical references for building interfaces with the design system — typograp
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/forms/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/forms/" aria-label="Form Patterns">
       <div class="card__inner">
         <div class="card__title">Form Patterns</div>
         <div class="card__desc">Form association, validation strategies, event handling, and submission patterns that work across all NYSDS form components.</div>
@@ -92,7 +92,7 @@ Practical references for building interfaces with the design system — typograp
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/utilities/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/foundations/utilities/" aria-label="Utilities">
       <div class="card__inner">
         <div class="card__title">Utilities</div>
         <div class="card__desc">Layout grid, flexbox, spacing, display, and responsive utility classes for rapid, consistent page layout.</div>
@@ -107,7 +107,7 @@ Need to look up a specific token value or component API? These are also always a
 
 <div class="nys-grid-row nys-grid-gap-300">
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/tokens/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/tokens/" aria-label="Token Browser">
       <div class="card__inner">
         <div class="card__title">Token Browser</div>
         <div class="card__desc">Browse all design tokens — colors, spacing, typography, and theme values — with an interactive theme switcher.</div>
@@ -115,7 +115,7 @@ Need to look up a specific token value or component API? These are also always a
     </a>
   </div>
   <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6">
-    <a class="card card__no-border card__flat nys-flex-fill" href="/components/">
+    <a class="card card__no-border card__flat nys-flex-fill" href="/components/" aria-label="Component Catalog">
       <div class="card__inner">
         <div class="card__title">Component Catalog</div>
         <div class="card__desc">All 27 NYSDS components — properties, events, accessibility details, and copy-paste examples.</div>

--- a/src/content/pages/foundations/tokens/index.njk
+++ b/src/content/pages/foundations/tokens/index.njk
@@ -142,7 +142,7 @@ heading_links: false
 
 <p>Ready to browse all tokens? The interactive token reference lets you see every token in the system with live previews.</p>
 
-<a class="card card--horizontal" href="/tokens/">
+<a class="card card--horizontal" href="/tokens/" aria-label="Color Tokens">
   <div class="card__inner">
     <div class="card__content">
       <div class="card__title">Color Tokens</div>
@@ -150,7 +150,7 @@ heading_links: false
     </div>
   </div>
 </a>
-<a class="card card--horizontal" href="/tokens/typography/">
+<a class="card card--horizontal" href="/tokens/typography/" aria-label="Typography Tokens">
   <div class="card__inner">
     <div class="card__content">
       <div class="card__title">Typography Tokens</div>
@@ -158,7 +158,7 @@ heading_links: false
     </div>
   </div>
 </a>
-<a class="card card--horizontal" href="/tokens/other/">
+<a class="card card--horizontal" href="/tokens/other/" aria-label="Spacing and Layout Tokens">
   <div class="card__inner">
     <div class="card__content">
       <div class="card__title">Spacing & Layout Tokens</div>

--- a/src/content/pages/foundations/typography.md
+++ b/src/content/pages/foundations/typography.md
@@ -263,7 +263,7 @@ For the complete list of typography utility classes with live previews, see [Typ
 
 <div class="nys-grid-row nys-grid-gap-300">
   <div class="nys-grid-col-12">
-    <a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds-fonts">
+    <a class="card card--horizontal" href="https://github.com/ITS-HCD/nysds-fonts" aria-label="NYSDS Fonts Repository">
       <div class="card__inner">
         <div class="card__media card__media--thin">
           <img src="/assets/img/font-card.svg" />

--- a/src/content/pages/get-started/designers.md
+++ b/src/content/pages/get-started/designers.md
@@ -23,7 +23,7 @@ The team also uses Figma variables to power agency theming. When you switch an a
 
 Designing and prototyping with the NYS Design System is powered by prebuilt Figma libraries that mirror the coded components. This connectedness makes it easier for designers and developers to collaborate and ensures that what is designed matches what is built.
 
-<a class="card card--horizontal" href="https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu/%F0%9F%92%A0-NYS-Design-System">
+<a class="card card--horizontal" href="https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu/%F0%9F%92%A0-NYS-Design-System" aria-label="NYS Design System for NYS Employees">
     <div class="card__inner">
         <div class="card__media card__media--thin">
             <img src="/assets/img/design-token-card.svg" />
@@ -41,7 +41,7 @@ Designing and prototyping with the NYS Design System is powered by prebuilt Figm
     </div>
 </a>
 
-<a class="card card--horizontal" href="https://www.figma.com/community/file/1574803287825265318">
+<a class="card card--horizontal" href="https://www.figma.com/community/file/1574803287825265318" aria-label="NYS Design System for the Community">
     <div class="card__inner">
         <div class="card__media card__media--thin">
             <img src="/assets/img/brand-card.svg" />
@@ -97,7 +97,7 @@ Open the local styles panel or use the selection colors section to see what desi
 
 Open the project template to see how components come together in realistic page layouts. These examples show common patterns like form pages, content pages, and navigation structures. Use them as starting points for your own work.
 
-<a class="card card--horizontal" href="https://www.figma.com/design/DS5Nm2AdMDzpelPfEJ2hnn/%F0%9F%94%B2-Project-Template?m=auto&t=NclNpstvX9JkuC7w-7">
+<a class="card card--horizontal" href="https://www.figma.com/design/DS5Nm2AdMDzpelPfEJ2hnn/%F0%9F%94%B2-Project-Template?m=auto&t=NclNpstvX9JkuC7w-7" aria-label="NYS Design System Project Template">
     <div class="card__inner">
         <div class="card__media card__media--thin">
             <img src="/assets/img/4-up-card.svg" />

--- a/src/content/pages/index.njk
+++ b/src/content/pages/index.njk
@@ -70,7 +70,7 @@ heading_links: false
   <h2>Foundational principles and visual identity</h2>
   <div class="nys-grid-row nys-grid-gap-300">
     <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6 nys-desktop:nys-grid-col-3 nys-display-flex">
-      <a class="card nys-flex-fill" href="/foundations/tokens">
+      <a class="card nys-flex-fill" href="/foundations/tokens" aria-label="Design Tokens">
         <div class="card__inner">
           <div class="card__media">
               <img src="/assets/img/design-token-card.svg" alt="">
@@ -81,7 +81,7 @@ heading_links: false
       </a>
     </div>
     <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6 nys-desktop:nys-grid-col-3 nys-display-flex">
-      <a class="card nys-flex-fill" href="/foundations/accessibility/">
+      <a class="card nys-flex-fill" href="/foundations/accessibility/" aria-label="Accessibility">
         <div class="card__inner">
           <div class="card__media">
               <img src="/assets/img/accessibility-card.svg" alt="">
@@ -92,7 +92,7 @@ heading_links: false
       </a>
     </div>
     <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6 nys-desktop:nys-grid-col-3 nys-display-flex">
-      <a class="card nys-flex-fill" href="/components/">
+      <a class="card nys-flex-fill" href="/components/" aria-label="Web Components">
         <div class="card__inner">
           <div class="card__media">
               <img src="/assets/img/web-component-card.svg" alt="">
@@ -103,7 +103,7 @@ heading_links: false
       </a>
     </div>
     <div class="nys-grid-col-12 nys-tablet:nys-grid-col-6 nys-desktop:nys-grid-col-3 nys-display-flex">
-      <a class="card nys-flex-fill" href="/foundations/utilities/typography/">
+      <a class="card nys-flex-fill" href="/foundations/utilities/typography/" aria-label="Typography">
         <div class="card__inner">
           <div class="card__media">
               <img src="/assets/img/typography-card.svg" alt="">
@@ -152,7 +152,7 @@ heading_links: false
         {% if post.data.tags | hasReleaseTag %}
           {% if not found_release %}
             {% set found_release = true %}
-            <a class="card card--horizontal" href="{{ post.url | url }}">
+            <a class="card card--horizontal" href="{{ post.url | url }}" aria-label="{{ post.data.title }}">
               <div class="card__inner">
                 <div class="card__media card__media--thin">
                   <img src="{{ post.data.thumbnailimage }}" alt="" role="presentation" />
@@ -179,7 +179,7 @@ heading_links: false
         {% if post.data.tags | hasArticleTag %}
           {% if not found_article %}
             {% set found_article = true %}
-            <a class="card card--horizontal" href="{{ post.url | url }}">
+            <a class="card card--horizontal" href="{{ post.url | url }}" aria-label="{{ post.data.title }}">
               <div class="card__inner">
                 <div class="card__media card__media--thin">
                   <img src="{{ post.data.thumbnailimage }}" alt="" role="presentation" />

--- a/src/content/pages/learn/index.njk
+++ b/src/content/pages/learn/index.njk
@@ -40,7 +40,7 @@ navOrder: 1
 
         {%- if list.length -%}
           {%- for post in list -%}
-            <a class="card card--horizontal" href="{{ post.url | url }}" title="Watch Video: {{ post.data.title | escape }}">
+            <a class="card card--horizontal" href="{{ post.url | url }}" aria-label="Watch Video: {{ post.data.title | escape }}">
               <div class="card__inner">
                 {% if post.data.video_url %}
                 <div class="card__media">

--- a/src/content/updates/2025-08-22-release-1.7.0.md
+++ b/src/content/updates/2025-08-22-release-1.7.0.md
@@ -15,7 +15,7 @@ date: 2025-08-22
 In this series, we’ll explain what a “design system” is and how ours works. Most importantly, we’ll show the value it can bring to you and to the residents that use what you build with it. Whether you’ve never used a design system before or you’re just new to ours, you’ll learn tips and ideas that will help you build better web applications and sites more quickly.
 <div class="nys-grid-row nys-grid-gap-300 nys-display-flex">
 <div class="nys-tablet:nys-grid-col-4">
-<a class="card" href="/videos/introducing-the-nys-design-system/" title="Watch Video: Introducing the NYS Design System">
+<a class="card" href="/videos/introducing-the-nys-design-system/" aria-label="Watch Video: Introducing the NYS Design System">
               <div class="card__inner">               
                 <div class="card__media">
                   <img src="https://i.ytimg.com/vi/-AzYrquG7E4/hq720.jpg" alt="Thumbnail image">
@@ -37,7 +37,7 @@ In this series, we’ll explain what a “design system” is and how ours works
 
 </div>
 <div class="nys-tablet:nys-grid-col-4">
-<a class="card" href="/videos/intro-to-designing-with-the-new-york-state-design-system/" title="Watch Video: Intro to Designing with the New York State Design System">
+<a class="card" href="/videos/intro-to-designing-with-the-new-york-state-design-system/" aria-label="Watch Video: Intro to Designing with the New York State Design System">
               <div class="card__inner">
                 <div class="card__media">
                   <img src="https://i.ytimg.com/vi/hSpJv_i-hIg/hq720.jpg" alt="Thumbnail image">
@@ -59,7 +59,7 @@ In this series, we’ll explain what a “design system” is and how ours works
 
 </div>
 <div class="nys-tablet:nys-grid-col-4">
-<a class="card" href="/videos/intro-to-nysds-web-components/" title="Watch Video: Intro to NYS Design System Web Components">
+<a class="card" href="/videos/intro-to-nysds-web-components/" aria-label="Watch Video: Intro to NYS Design System Web Components">
               <div class="card__inner">
                 <div class="card__media">
                   <img src="https://i.ytimg.com/vi/NM5PFClfBgA/hq720.jpg" alt="Thumbnail image">


### PR DESCRIPTION
## Summary
- Replaced `title` attributes with `aria-label` on card links that had them (components index, learn page, release post)
- Added `aria-label` to all remaining card links site-wide (~35 cards across 9 files) that had no accessible name beyond child content

## Test plan
- [ ] Verify card links render correctly across the site (homepage, foundations, accessibility, contribute, designers, tokens, typography, learn)
- [ ] Screen reader check: confirm each card link announces its aria-label
- [ ] No visual regressions (aria-label is invisible; removed title tooltips are intentional)