### PR TITLE
docs: reflect April 2026 DOJ deadline extension (WCAG 2.1 dates → Apr 26 2027)

### DIFF
--- a/src/content/pages/foundations/accessibility/index.md
+++ b/src/content/pages/foundations/accessibility/index.md
@@ -232,8 +232,7 @@ navOrder: 2
   <p>Don't get lost in the deadline math. Our standard is <b>WCAG 2.2 AA</b>. That's what New York requires, that's our accessibility team tests against, and that's what teams should be building to. For full policy details, compliance requirements, and planning guidance, see our <a href="/foundations/accessibility/leadership/">Leadership Guidance</a>.</p>
   <ul>
     <li><b>January 2027</b> — NYS Technology Law (STL Section 103-d) requires all State Entity websites conform to WCAG 2.2 Level AA.</li>
-    <li><b>April 26, 2027</b> — DOJ Rule requires web content and mobile applications to conform to WCAG 2.1 Level AA (public entities serving 50,000 or more people).</li>
-    <li><b>April 26, 2028</b> — DOJ Rule deadline for entities serving fewer than 50,000 people and special district governments.</li>
+    <li><b>April 26, 2027</b> — DOJ Rule requires all web content and mobile applications conform to WCAG 2.1 Level AA.</li>
   </ul>
 </nys-alert>
 

--- a/src/content/pages/foundations/accessibility/index.md
+++ b/src/content/pages/foundations/accessibility/index.md
@@ -232,7 +232,8 @@ navOrder: 2
   <p>Don't get lost in the deadline math. Our standard is <b>WCAG 2.2 AA</b>. That's what New York requires, that's our accessibility team tests against, and that's what teams should be building to. For full policy details, compliance requirements, and planning guidance, see our <a href="/foundations/accessibility/leadership/">Leadership Guidance</a>.</p>
   <ul>
     <li><b>January 2027</b> — NYS Technology Law (STL Section 103-d) requires all State Entity websites conform to WCAG 2.2 Level AA.</li>
-    <li><b>April 2027</b> — DOJ Rule requires all web content and mobile applications conform to WCAG 2.1 Level AA.</li>
+    <li><b>April 26, 2027</b> — DOJ Rule requires web content and mobile applications to conform to WCAG 2.1 Level AA (public entities serving 50,000 or more people).</li>
+    <li><b>April 26, 2028</b> — DOJ Rule deadline for entities serving fewer than 50,000 people and special district governments.</li>
   </ul>
 </nys-alert>
 

--- a/src/content/pages/foundations/accessibility/leadership.md
+++ b/src/content/pages/foundations/accessibility/leadership.md
@@ -18,15 +18,19 @@ Accessibility compliance is a legal requirement for every New York State digital
 
 ## Compliance Deadlines
 
-There are two federal and state mandates that apply to New York State digital services. Both require conformance to the Web Content Accessibility Guidelines (WCAG) at Level AA, but they have different deadlines and scope. Here's what you need to know:
+Two mandates apply to New York State digital services — one state, one federal. Both require conformance to the Web Content Accessibility Guidelines (WCAG) at Level AA, but they differ in deadline, standard, and scope. (In April 2026, the U.S. Department of Justice extended its ADA Title II compliance dates by one year; the federal dates below reflect that extension.) Here's what you need to know:
 
 ### January 2027
 
 [NYS Technology Law (STL §103-d)](https://www.nysenate.gov/legislation/laws/STT/103-D) - New York State websites must meet <strong>WCAG 2.2 Level AA</strong>. This is a higher standard than the federal rule and applies to all state agencies, including third-party vendor-managed sites.
 
-### April 2027 
+### April 26, 2027
 
-[DOJ Rule (28 CFR Part 35)](https://www.ecfr.gov/current/title-28/part-35#p-35.200(b)(1)) - All state and local government web content (including PDFs) and mobile apps must meet **WCAG 2.1 Level AA**. This applies to entities serving populations of 50,000 or more.
+[DOJ Rule (28 CFR Part 35)](https://www.ecfr.gov/current/title-28/part-35#p-35.200(b)(1)) - State and local government web content (including PDFs) and mobile apps must meet **WCAG 2.1 Level AA**. This deadline applies to public entities serving a population of 50,000 or more.
+
+### April 26, 2028
+
+The same DOJ Rule applies to public entities serving a population under 50,000 and to special district governments, which have until this later date to meet **WCAG 2.1 Level AA**.
 
 <nys-alert type="info" heading="Which WCAG version should we target?">
 WCAG 2.2 builds on previous versions. Target that version now to meet both deadlines with a single effort.
@@ -41,7 +45,7 @@ WCAG 2.2 builds on previous versions. Target that version now to meet both deadl
 ITS Policy NYS-P08-005 establishes minimum accessibility requirements for all Information and Communication Technology (ICT) developed, procured, maintained, or used by State Entities. The policy requires:
 
 - **WCAG 2.2 Level AA conformance** for all SE websites, including those provided by third parties, by January 2027 (STL Section 103-d).
-- **WCAG 2.1 Level AA conformance** for all web content and mobile applications by April 2027 (DOJ Rule).
+- **WCAG 2.1 Level AA conformance** for all web content and mobile applications by April 26, 2027 for public entities serving 50,000 or more people, and by April 26, 2028 for smaller entities and special district governments (DOJ Rule).
 - **Manual testing** of ICT before production use, prior to any fundamental alterations, and biennially thereafter.
 - **Documented testing reports** maintained for each ICT until the next testing cycle.
 - **An inventory** of all ICTs and their current compliance status.

--- a/src/content/pages/foundations/accessibility/leadership.md
+++ b/src/content/pages/foundations/accessibility/leadership.md
@@ -18,7 +18,7 @@ Accessibility compliance is a legal requirement for every New York State digital
 
 ## Compliance Deadlines
 
-Two mandates apply to New York State digital services — one state, one federal. Both require conformance to the Web Content Accessibility Guidelines (WCAG) at Level AA, but they differ in deadline, standard, and scope. (In April 2026, the U.S. Department of Justice extended its ADA Title II compliance dates by one year; the federal dates below reflect that extension.) Here's what you need to know:
+Two mandates apply to New York State digital services — one state, one federal. Both require conformance to the Web Content Accessibility Guidelines (WCAG) at Level AA, but they differ in deadline, standard, and scope. (In April 2026, the U.S. Department of Justice extended its ADA Title II compliance date by one year; the federal date below reflects that extension.) Here's what you need to know:
 
 ### January 2027
 
@@ -26,11 +26,7 @@ Two mandates apply to New York State digital services — one state, one federal
 
 ### April 26, 2027
 
-[DOJ Rule (28 CFR Part 35)](https://www.ecfr.gov/current/title-28/part-35#p-35.200(b)(1)) - State and local government web content (including PDFs) and mobile apps must meet **WCAG 2.1 Level AA**. This deadline applies to public entities serving a population of 50,000 or more.
-
-### April 26, 2028
-
-The same DOJ Rule applies to public entities serving a population under 50,000 and to special district governments, which have until this later date to meet **WCAG 2.1 Level AA**.
+[DOJ Rule (28 CFR Part 35)](https://www.ecfr.gov/current/title-28/part-35#p-35.200(b)(1)) - State and local government web content (including PDFs) and mobile apps must meet **WCAG 2.1 Level AA**.
 
 <nys-alert type="info" heading="Which WCAG version should we target?">
 WCAG 2.2 builds on previous versions. Target that version now to meet both deadlines with a single effort.
@@ -45,7 +41,7 @@ WCAG 2.2 builds on previous versions. Target that version now to meet both deadl
 ITS Policy NYS-P08-005 establishes minimum accessibility requirements for all Information and Communication Technology (ICT) developed, procured, maintained, or used by State Entities. The policy requires:
 
 - **WCAG 2.2 Level AA conformance** for all SE websites, including those provided by third parties, by January 2027 (STL Section 103-d).
-- **WCAG 2.1 Level AA conformance** for all web content and mobile applications by April 26, 2027 for public entities serving 50,000 or more people, and by April 26, 2028 for smaller entities and special district governments (DOJ Rule).
+- **WCAG 2.1 Level AA conformance** for all web content and mobile applications by April 26, 2027 (DOJ Rule).
 - **Manual testing** of ICT before production use, prior to any fundamental alterations, and biennially thereafter.
 - **Documented testing reports** maintained for each ICT until the next testing cycle.
 - **An inventory** of all ICTs and their current compliance status.


### PR DESCRIPTION
## What
Updates the accessibility pages to reflect the **April 2026 federal extension** of the DOJ ADA Title II (28 CFR Part 35) compliance date.

## Why
The DOJ's original Title II compliance date was extended by one year in April 2026. The pages named the deadline only as "April 2027"; this pins the precise date and notes the extension so agencies plan to the correct federal deadline.

## Changes
**Legal Requirements / Accessibility for Leadership** (`foundations/accessibility/leadership.md`)
- DOJ deadline → **April 26, 2027**
- Intro notes the April 2026 extension shifted the original date by one year
- ITS Policy bullet updated to the precise date

**Accessibility landing page** (`foundations/accessibility/index.md`)
- Deadlines callout updated to **April 26, 2027** to match

WCAG 2.1 AA is retained as the DOJ standard (that's what 28 CFR Part 35 requires; the pages already advise targeting 2.2 to cover both mandates). The smaller-entity / special-district tier is intentionally omitted — it does not apply to New York State.

## Note
The DOJ date on these pages was already "April 2027" (updated in a43bad251), not the pre-extension April 2026 — this PR pins the precise date and adds the extension framing.
