### PR TITLE
Fix stale design token references in site CSS

### DIFF
--- a/src/assets/css/nysds-site.css
+++ b/src/assets/css/nysds-site.css
@@ -94,7 +94,7 @@ li {
 }
 
 li::marker {
-    color: var(--nys-color-theme-primary, #000);
+    color: var(--nys-color-theme, #000);
 }
 
 /* Links */
@@ -1178,10 +1178,10 @@ li > .section-nav__list {
 
 .token-list__swatch--checkerboard {
     background-image:
-        linear-gradient(45deg, var(--nys-color-neutral-40, #f6f6f6) 25%, transparent 25%),
-        linear-gradient(-45deg, var(--nys-color-neutral-40, #f6f6f6) 25%, transparent 25%),
-        linear-gradient(45deg, transparent 75%, var(--nys-color-neutral-40, #f6f6f6) 75%),
-        linear-gradient(-45deg, transparent 75%, var(--nys-color-neutral-40, #f6f6f6) 75%);
+        linear-gradient(45deg, var(--nys-color-neutral-10, #f6f6f6) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--nys-color-neutral-10, #f6f6f6) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--nys-color-neutral-10, #f6f6f6) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--nys-color-neutral-10, #f6f6f6) 75%);
     background-size: 20px 20px;
     background-position:
         0 0,
@@ -1376,8 +1376,8 @@ li > .section-nav__list {
 
 .code-preview__buttons .code-preview__dropdown p {
     margin: 0;
-    font-family: var(--nys-type-family-ui, "Proxima Nova");
-    font-size: var(--nys-type-size-ui-md, 16px);
+    font-family: var(--nys-font-family-ui, "Proxima Nova");
+    font-size: var(--nys-font-size-ui-md, 16px);
     font-style: normal;
     font-weight: 600;
     line-height: var(--nys-font-lineheight-ui-md, 24px);
@@ -1426,8 +1426,8 @@ li > .section-nav__list {
     align-self: stretch;
     border-top: 1px solid var(--nys-color-neutral-50, #ededed);
     background: var(--nys-color-black-transparent-50, rgba(0, 0, 0, 0.01));
-    font-family: var(--nys-type-family-ui, "Proxima Nova");
-    font-size: var(--nys-type-size-ui-sm, 14px);
+    font-family: var(--nys-font-family-ui, "Proxima Nova");
+    font-size: var(--nys-font-size-ui-sm, 14px);
     font-style: normal;
     font-weight: 400;
     line-height: var(--nys-font-lineheight-ui-sm, 24px);
@@ -1463,8 +1463,8 @@ li > .section-nav__list {
     border-radius: var(--nys-radius-md, 4px);
     border: var(--nys-border-width-sm, 1px) solid var(--nys-color-ink, #1b1b1b);
     background: var(--nys-color-ink, #1b1b1b);
-    font-family: var(--nys-type-family-ui, "Proxima Nova");
-    font-size: var(--nys-type-size-ui-sm, 14px);
+    font-family: var(--nys-font-family-ui, "Proxima Nova");
+    font-size: var(--nys-font-size-ui-sm, 14px);
     font-style: normal;
     font-weight: 400;
     line-height: var(--nys-font-lineheight-ui-sm, 24px);

--- a/src/assets/nysa11y/accordion-custom.css
+++ b/src/assets/nysa11y/accordion-custom.css
@@ -31,7 +31,7 @@
                 color: var(--nys-color-ink, #1b1b1b);
                 display: flex;
                 font-family: inherit;
-                font-size: var(--nys-type-size-ui-xl, 20px);
+                font-size: var(--nys-font-size-ui-xl, 20px);
                 font-weight: var(--nys-font-weight-bold, 700);
                 gap: 0.5rem;
                 line-height: 1.5rem;

--- a/src/assets/nysa11y/accordion-native.css
+++ b/src/assets/nysa11y/accordion-native.css
@@ -29,7 +29,7 @@
                 border-radius: 0.25rem;
                 color: var(--nys-color-ink, #1b1b1b);
                 display: flex;
-                font-size: var(--nys-type-size-ui-xl, 20px);
+                font-size: var(--nys-font-size-ui-xl, 20px);
                 font-weight: var(--nys-font-weight-bold, 700);
                 gap: 0.5rem;
                 line-height: 1.5rem;


### PR DESCRIPTION
## Summary

A Project Wallace CSS analysis flagged several `no-unknown-custom-properties` warnings in the site's own CSS. These were references to token names that don't exist in NYSDS — each had a hard-coded fallback that was silently rendering instead of tracking the design system.

| File | Was | Now |
|---|---|---|
| `nysds-site.css` (li::marker) | `--nys-color-theme-primary` | `--nys-color-theme` |
| `nysds-site.css` (token swatch checkerboard) | `--nys-color-neutral-40` | `--nys-color-neutral-10` |
| `nysds-site.css` (code preview UI, ×3) | `--nys-type-family-ui` | `--nys-font-family-ui` |
| `nysds-site.css` (code preview UI, ×3) | `--nys-type-size-ui-md` / `-sm` | `--nys-font-size-ui-md` / `-sm` |
| `nysa11y/accordion-{custom,native}.css` | `--nys-type-size-ui-xl` | `--nys-font-size-ui-xl` |

All replacement tokens verified against the NYSDS token registry; `--nys-color-neutral-10` resolves to `#f6f6f6`, identical to the old fallback.

## Visual impact

Effectively none — fallback values matched (or closely approximated) the real token values. The one intentional behavior fix: list markers now follow the active agency theme color instead of falling back to black, which was the rule's original intent.

## Notes

The vendor NYSDS bundle (`nysds-full.min.css`) contains the same stale `--nys-color-theme-primary` reference — that's an upstream issue for the core nysds repo, not touched here. `foundations/styles.md` also mentions `--nys-color-theme-primary` in prose; left as-is pending the upstream fix.