### PR TITLE
Fix broken /updates/css-variables/ URL with reusable redirect_from support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -69,6 +69,24 @@ module.exports = async function (eleventyConfig) {
   eleventyConfig.addCollection("updates", updates);
   eleventyConfig.addCollection("videos", videos);
 
+  // Redirects: any page can declare `redirect_from` (string or array of old
+  // URLs) in its front matter. This collection flattens those into {from, to}
+  // pairs, which src/redirects.njk paginates into static redirect stubs — the
+  // GitHub Pages-friendly way to keep old URLs working after a page moves.
+  eleventyConfig.addCollection("redirects", (collectionApi) => {
+    const redirects = [];
+    for (const page of collectionApi.getAll()) {
+      const from = page.data.redirect_from;
+      if (!from) continue;
+      const froms = Array.isArray(from) ? from : [from];
+      for (const url of froms) {
+        // Normalize: strip trailing slash so the permalink can append one.
+        redirects.push({ from: url.replace(/\/+$/, ""), to: page.url });
+      }
+    }
+    return redirects;
+  });
+
   // CSS
   eleventyConfig.addWatchTarget("./src/css/");
 

--- a/src/content/pages/foundations/accessibility/index.md
+++ b/src/content/pages/foundations/accessibility/index.md
@@ -1,6 +1,5 @@
 ---
 permalink: /foundations/accessibility/
-redirect_from: /a11y/
 title: "Accessibility"
 description: "The New York State Design System makes it easier to build accessible, usable websites for New York State."
 section: "Foundations"

--- a/src/content/updates/2026-04-21-css-variables.md
+++ b/src/content/updates/2026-04-21-css-variables.md
@@ -1,5 +1,6 @@
 ---
 permalink: /about/updates/css-variables/
+redirect_from: /updates/css-variables/
 title: How CSS Variables Power the NYS Design System
 author: Emily Gorelik
 description: How the NYS Design System uses CSS variables and design tokens to enable consistent, scalable, and customizable UI development across New York State.

--- a/src/redirects.njk
+++ b/src/redirects.njk
@@ -1,0 +1,22 @@
+---
+# Generates a static redirect stub for every `redirect_from` entry declared in
+# any page's front matter (see the "redirects" collection in .eleventy.js).
+# One stub is written to each old URL, pointing at the page's current location.
+eleventyExcludeFromCollections: true
+pagination:
+  data: collections.redirects
+  size: 1
+  alias: redirect
+  addAllPagesToCollections: false
+permalink: "{{ redirect.from }}/index.html"
+---
+<!DOCTYPE html>
+<html lang="en-US" dir="ltr">
+  <meta charset="utf-8" />
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ redirect.to | url }}" />
+  <script>location = "{{ redirect.to | url }}";</script>
+  <meta http-equiv="refresh" content="0; url={{ redirect.to | url }}" />
+  <meta name="robots" content="noindex" />
+  <a href="{{ redirect.to | url }}">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
## Summary
The old article URL `https://designsystem.ny.gov/updates/css-variables/` 404s — the article now lives at `/about/updates/css-variables/`. This adds a redirect and a small reusable mechanism to handle URL moves going forward.

## What changed
- **`.eleventy.js`** — new `redirects` collection that flattens any page's `redirect_from` front matter (string or array of old URLs) into `{from, to}` pairs.
- **`src/redirects.njk`** — generator that paginates that collection into a static redirect stub at each old URL (canonical link + JS + meta refresh + `noindex` + fallback link). This is the GitHub Pages-friendly way to keep old links alive after a page moves.
- **css-variables article** — added `redirect_from: /updates/css-variables/` → redirects to `/about/updates/css-variables/`.
- **accessibility page** — removed a stale `redirect_from: /a11y/`. It was dead front matter (nothing consumed it before). `/a11y/` is now the live GAAD landing page, so activating that redirect would have clobbered it — Eleventy's duplicate-permalink check caught this during the build.

## How to add redirects in the future
Add one line to the destination page's front matter:
```yaml
redirect_from: /old/url/
# or several:
redirect_from: [/old/url/, /another/old/url/]
```

## Verification
`npm run build` passes. Confirmed in `_site`:
- `/updates/css-variables/index.html` → redirect stub pointing at `/about/updates/css-variables/`
- `/about/updates/css-variables/` destination intact
- `/a11y/` still the live GAAD page (not a redirect)
- `/foundations/accessibility/` intact