### PR TITLE
Fix publishing of unfilled a11y checklists, dead dependencies block, and page titles

### DIFF
--- a/src/_includes/layouts/component.njk
+++ b/src/_includes/layouts/component.njk
@@ -96,6 +96,11 @@
     {%- block events %}{% endblock -%}
 </section>
 
+{#- The Dependencies section renders only when a page fills this block; the
+    heading lives in partials/dependencies.njk so pages that declare no
+    dependencies do not emit a bare, empty <h2>. -#}
+{%- block dependencies %}{% endblock -%}
+
 <section class="nys-section">
     <h2>Suggest a New Component</h2>
     <div class="nys-grid-row nys-grid-gap">

--- a/src/_includes/partials/dependencies.njk
+++ b/src/_includes/partials/dependencies.njk
@@ -1,21 +1,13 @@
-<div>
-{% if dependencies and dependencies | length > 0 %}
-    <p>
-        This component automatically imports the following dependencies:
-    </p>
-
-    <ul>
-        {% for dependency in dependencies %}
-       <li><code>{{ dependency }}</code></li>
-       {% endfor %}
-    </ul>
-
-        
-  {% else %}
-    <p>
-      There are no existing dependencies for this component. Explore existing <a href="#options">options</a>, or
-      propose a new one with a
-      <a href="https://github.com/ITS-HCD/nysds/discussions/categories/component-proposals">Component Proposal</a>.
-    </p>
-  {% endif %}
-  </div>
+<section>
+<h2>Dependencies</h2>
+{%- if dependencies and dependencies | length > 0 -%}
+<p>This component automatically imports the following dependencies:</p>
+<ul>
+{%- for dependency in dependencies %}
+<li><code>{{ dependency }}</code></li>
+{%- endfor %}
+</ul>
+{%- else -%}
+<p>There are no existing dependencies for this component. Explore existing <a href="#options">options</a>, or propose a new one with a <a href="https://github.com/ITS-HCD/nysds/discussions/categories/component-proposals">Component Proposal</a>.</p>
+{%- endif -%}
+</section><br>

--- a/src/_includes/partials/dependencies.njk
+++ b/src/_includes/partials/dependencies.njk
@@ -8,6 +8,6 @@
 {%- endfor %}
 </ul>
 {%- else -%}
-<p>There are no existing dependencies for this component. Explore existing <a href="#options">options</a>, or propose a new one with a <a href="https://github.com/ITS-HCD/nysds/discussions/categories/component-proposals">Component Proposal</a>.</p>
+<p>This component does not import any other NYSDS components.</p>
 {%- endif -%}
 </section><br>

--- a/src/_includes/partials/head-meta.njk
+++ b/src/_includes/partials/head-meta.njk
@@ -1,7 +1,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>{% if section != 'home' %}{% if title %}{{ title | safe }}{% endif %}{% endif %}</title>
+{#- The home page carries the site name as its own title, so appending it there
+    doubles it. Everywhere else the suffix is what identifies the site in tab
+    strips and search results. A page with no title still gets one (WCAG 2.4.2). -#}
+<title>{% if title %}{{ title | safe }}{% if page.url != "/" %} - {{ site.title }}{% endif %}{% else %}{{ site.title }}{% endif %}</title>
 {% if description %}
 <meta name="description" content="{{ description }}">{% endif %}
 <link rel="canonical" href="{{ site.url }}{{page.url}}">

--- a/src/content/components/alert/a11y-tests.njk
+++ b/src/content/components/alert/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/alert-header.svg
 stable: true
 parent: Alert
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in alert.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/avatar/a11y-tests.njk
+++ b/src/content/components/avatar/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/avatar-header.svg
 stable: true
 parent: Avatar
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in avatar.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/backtotop/a11y-tests.njk
+++ b/src/content/components/backtotop/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/backtotop-header.svg
 stable: true
 parent: Back To Top
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in backtotop.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/badge/a11y-tests.njk
+++ b/src/content/components/badge/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/badge-header.svg
 stable: true
 parent: Badge
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in badge.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/breadcrumbs/index.md
+++ b/src/content/components/breadcrumbs/index.md
@@ -257,4 +257,15 @@ breadcrumbs.addEventListener("nys-expand", () => {
 {% include "partials/code-preview.njk" %}
 {% endblock %}
 
+
+{% block dependencies %}
+
+{% set dependencies = [
+  "<nys-icon>"
+] %}
+
+{% include "partials/dependencies.njk" %}
+
+{% endblock %}
+
 {% block updates %}{% endblock %}

--- a/src/content/components/button/a11y-tests.njk
+++ b/src/content/components/button/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/button-header.svg
 stable: true
 parent: button
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in button.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/card/a11y-tests.njk
+++ b/src/content/components/card/a11y-tests.njk
@@ -5,10 +5,11 @@ description: How to test the accessibility of a card.
 stable: true
 parent: Card
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in card.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/checkbox/a11y-tests.njk
+++ b/src/content/components/checkbox/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/checkbox-header.svg
 stable: true
 parent: Checkbox
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in checkbox.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/checkbox/index.md
+++ b/src/content/components/checkbox/index.md
@@ -377,7 +377,7 @@ checkbox.addEventListener('nys-change', (event) => {
 {% block dependencies %}
 
 {% set dependencies = [
-  "<nys-icon>"
+  "<nys-errormessage>", "<nys-icon>", "<nys-label>", "<nys-textinput>"
 ] %}
 
 {% include "partials/dependencies.njk" %}

--- a/src/content/components/combobox/a11y-tests.njk
+++ b/src/content/components/combobox/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/combobox-header.svg
 stable: true
 parent: Combobox
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in combobox.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/combobox/index.md
+++ b/src/content/components/combobox/index.md
@@ -881,3 +881,13 @@ combobox.addEventListener('nys-input', (event) => {
 {% set codeLanguage = "js" %}
 {% include "partials/code-preview.njk" %}
 {% endblock %}
+
+{% block dependencies %}
+
+{% set dependencies = [
+  "<nys-button>", "<nys-errormessage>", "<nys-icon>", "<nys-label>"
+] %}
+
+{% include "partials/dependencies.njk" %}
+
+{% endblock %}

--- a/src/content/components/datepicker/a11y-tests.njk
+++ b/src/content/components/datepicker/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/datepicker-header.svg
 stable: true
 parent: Datepicker
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in datepicker.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/datepicker/index.md
+++ b/src/content/components/datepicker/index.md
@@ -386,7 +386,7 @@ datepicker.addEventListener("nys-blur", () => {
 {% block dependencies %}
 
 {% set dependencies = [
-  "<wc-datepicker>","<nys-icon>","<nys-button>"
+  "<nys-button>", "<nys-errormessage>", "<nys-icon>", "<nys-label>"
 ] %}
 
 {% include "partials/dependencies.njk" %}

--- a/src/content/components/divider/a11y-tests.njk
+++ b/src/content/components/divider/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/divider-header.svg
 stable: true
 parent: Divider
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in divider.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/dropdownmenu/a11y-tests.njk
+++ b/src/content/components/dropdownmenu/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/dropdownmenu-header.svg
 stable: true
 parent: Dropdown Menu
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in dropdownmenu.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/fileinput/a11y-tests.njk
+++ b/src/content/components/fileinput/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/fileinput-header.svg
 stable: true
 parent: File Input
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in fileinput.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/fileinput/index.md
+++ b/src/content/components/fileinput/index.md
@@ -301,7 +301,7 @@ fileinput.addEventListener("nys-change", () => {
 {% block dependencies %}
 
 {% set dependencies = [
-"<nys-icon>", "<nys-button>"
+  "<nys-button>", "<nys-errormessage>", "<nys-icon>", "<nys-label>"
 ] %}
 
 {% include "partials/dependencies.njk" %}

--- a/src/content/components/globalfooter/a11y-tests.njk
+++ b/src/content/components/globalfooter/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/global-footer-header.svg
 stable: true
 parent: Global Footer
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in globalfooter.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/globalfooter/index.md
+++ b/src/content/components/globalfooter/index.md
@@ -189,4 +189,15 @@ This component does not emit any custom events.
 
 {% endblock %}
 
+
+{% block dependencies %}
+
+{% set dependencies = [
+  "<nys-divider>"
+] %}
+
+{% include "partials/dependencies.njk" %}
+
+{% endblock %}
+
 {% block updates %}{% endblock %}

--- a/src/content/components/globalheader/a11y-tests.njk
+++ b/src/content/components/globalheader/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/global-header-header.svg
 stable: true
 parent: Global Header
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in globalheader.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/globalheader/index.md
+++ b/src/content/components/globalheader/index.md
@@ -201,4 +201,15 @@ This component does not emit any custom events.
 
 {% endblock %}
 
+
+{% block dependencies %}
+
+{% set dependencies = [
+  "<nys-icon>"
+] %}
+
+{% include "partials/dependencies.njk" %}
+
+{% endblock %}
+
 {% block updates %}{% endblock %}

--- a/src/content/components/icon/a11y-tests.njk
+++ b/src/content/components/icon/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/icon-header.svg
 stable: true
 parent: Icon
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in icon.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/iconlist/a11y-tests.njk
+++ b/src/content/components/iconlist/a11y-tests.njk
@@ -5,10 +5,11 @@ description: How to test the accessibility of an icon list.
 stable: true
 parent: Icon List
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in iconlist.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/iconlist/index.md
+++ b/src/content/components/iconlist/index.md
@@ -155,4 +155,15 @@ This component does not emit any custom events.
 
 {% endblock %}
 
+
+{% block dependencies %}
+
+{% set dependencies = [
+  "<nys-icon>"
+] %}
+
+{% include "partials/dependencies.njk" %}
+
+{% endblock %}
+
 {% block updates %}{% endblock %}

--- a/src/content/components/modal/a11y-tests.njk
+++ b/src/content/components/modal/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/modal-header.svg
 stable: true
 parent: Modal
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in modal.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/pagination/a11y-tests.njk
+++ b/src/content/components/pagination/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/pagination-header.svg
 stable: true
 parent: Pagination
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in pagination.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/processlist/a11y-tests.njk
+++ b/src/content/components/processlist/a11y-tests.njk
@@ -5,10 +5,11 @@ description: How to test the accessibility of a process list.
 stable: true
 parent: Process List
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in processlist.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/radiobutton/a11y-tests.njk
+++ b/src/content/components/radiobutton/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/radiobutton-header.svg
 stable: true
 parent: Radio Button
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in radiobutton.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/radiobutton/index.md
+++ b/src/content/components/radiobutton/index.md
@@ -412,4 +412,15 @@ radiogroup.addEventListener('nys-change', (event) => {
 {% include "partials/code-preview.njk" %}
 {% endblock %}
 
+
+{% block dependencies %}
+
+{% set dependencies = [
+  "<nys-errormessage>", "<nys-label>", "<nys-textinput>"
+] %}
+
+{% include "partials/dependencies.njk" %}
+
+{% endblock %}
+
 {% block updates %}{% endblock %}

--- a/src/content/components/select/a11y-tests.njk
+++ b/src/content/components/select/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/select-header.svg
 stable: true
 parent: Select
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in select.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/select/index.md
+++ b/src/content/components/select/index.md
@@ -383,8 +383,8 @@ select.addEventListener('nys-change', (event) => {
 {% block dependencies %}
 
 {% set dependencies = [
-   "<nys-icon>"
-  ] %}
+  "<nys-errormessage>", "<nys-icon>", "<nys-label>"
+] %}
 
 {% include "partials/dependencies.njk" %}
 

--- a/src/content/components/skipnav/a11y-tests.njk
+++ b/src/content/components/skipnav/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/skipnav-header.svg
 stable: true
 parent: Skip Navigation
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in skipnav.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/stepper/a11y-tests.njk
+++ b/src/content/components/stepper/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/stepper-header.svg
 stable: true
 parent: Stepper
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in stepper.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/stepper/index.md
+++ b/src/content/components/stepper/index.md
@@ -382,9 +382,7 @@ stepper.addEventListener("nys-step-click", () => {
 
 {% block dependencies %}
 
-{% set dependencies = [
-   "<nys-button>"
-  ] %}
+{% set dependencies = [] %}
 
 {% include "partials/dependencies.njk" %}
 

--- a/src/content/components/table/a11y-tests.njk
+++ b/src/content/components/table/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/table-header.svg
 stable: true
 parent: Table
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in table.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/table/index.md
+++ b/src/content/components/table/index.md
@@ -406,7 +406,7 @@ table.addEventListener('nys-column-sort', (event) => {
 {% block dependencies %}
 
 {% set dependencies = [
-   "<nys-icon>,<nys-button>"
+   "<nys-icon>", "<nys-button>"
   ] %}
 
 {% include "partials/dependencies.njk" %}

--- a/src/content/components/textarea/a11y-tests.njk
+++ b/src/content/components/textarea/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/textarea-header.svg
 stable: true
 parent: Text Area
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in textarea.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/textarea/index.md
+++ b/src/content/components/textarea/index.md
@@ -338,8 +338,8 @@ textarea.addEventListener('nys-input', (event) => {
 {% block dependencies %}
 
 {% set dependencies = [
-   "<nys-icon>"
-  ] %}
+  "<nys-errormessage>", "<nys-label>"
+] %}
 
 {% include "partials/dependencies.njk" %}
 

--- a/src/content/components/textinput/a11y-tests.njk
+++ b/src/content/components/textinput/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/textinput-header.svg
 stable: true
 parent: Text Input
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in textinput.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/textinput/index.md
+++ b/src/content/components/textinput/index.md
@@ -424,8 +424,8 @@ textinput.addEventListener('nys-input', (event) => {
 {% block dependencies %}
 
 {% set dependencies = [
-   "<nys-icon>"
-  ] %}
+  "<nys-button>", "<nys-errormessage>", "<nys-icon>", "<nys-label>"
+] %}
 
 {% include "partials/dependencies.njk" %}
 

--- a/src/content/components/toggle/a11y-tests.njk
+++ b/src/content/components/toggle/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/toggle-header.svg
 stable: true
 parent: Toggle
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in toggle.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/toggle/index.md
+++ b/src/content/components/toggle/index.md
@@ -255,8 +255,8 @@ toggle.addEventListener('nys-change', (event) => {
 {% block dependencies %}
 
 {% set dependencies = [
-   "<nys-icon>"
-  ] %}
+  "<nys-icon>", "<nys-label>"
+] %}
 
 {% include "partials/dependencies.njk" %}
 

--- a/src/content/components/tooltip/a11y-tests.njk
+++ b/src/content/components/tooltip/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/tooltip-header.svg
 stable: true
 parent: Tooltip
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in tooltip.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/unavfooter/a11y-tests.njk
+++ b/src/content/components/unavfooter/a11y-tests.njk
@@ -8,10 +8,11 @@ image_footer: /assets/img/components/unav-footer-header.svg
 stable: true
 parent: UNav Footer
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in unavfooter.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/unavheader/a11y-tests.njk
+++ b/src/content/components/unavheader/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/unav-header-header.svg
 stable: true
 parent: UNav Header
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in unavheader.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#

--- a/src/content/components/unavheader/index.md
+++ b/src/content/components/unavheader/index.md
@@ -203,4 +203,15 @@ This component emits **two** custom Javascript events:
 
 {% endblock %}
 
+
+{% block dependencies %}
+
+{% set dependencies = [
+  "<nys-alert>", "<nys-button>", "<nys-icon>", "<nys-textinput>"
+] %}
+
+{% include "partials/dependencies.njk" %}
+
+{% endblock %}
+
 {% block updates %}{% endblock %}

--- a/src/content/components/verticalnav/index.md
+++ b/src/content/components/verticalnav/index.md
@@ -481,7 +481,7 @@ verticalnav.addEventListener('nys-verticalnav-toggle', (event) => {
 {% block dependencies %}
 
 {% set dependencies = [
-"<nys-accordion>", "<nys-accordionitem>", "<nys-verticalnavgroup>"
+"<nys-accordion>", "<nys-icon>"
 ] %}
 
 {% include "partials/dependencies.njk" %}

--- a/src/content/components/video/a11y-tests.njk
+++ b/src/content/components/video/a11y-tests.njk
@@ -8,10 +8,11 @@ image_header: /assets/img/components/videoplayer-header.svg
 stable: true
 parent: Video Player
 navOrder: 1
+draft: true # checklist data is still the unfilled scaffold; remove to publish
 eleventyExcludeFromCollections: true
 ---
 
-<!-- Remove eleventyExcludeFromCollections to render page -->
+<!-- Fill in video.11tydata.json5, then remove `draft: true` to publish this page -->
 {% extends "layouts/component-a11y-tests.njk" %}
 
 {#


### PR DESCRIPTION
Closes #551.

Follow-ups to #528, which merged while this was in flight. Three site-wide template/data bugs.

## Unfilled accessibility checklists were publishing

`eleventyExcludeFromCollections` keeps a page out of nav and collections but does not stop it building, so 31 `accessibility-tests` pages were live with scaffold text — `WHEN I k1` / `THEN outcome k1` and 0/0/0/0 status tables.

`components.11tydata.js` already returns `permalink: false` for drafts, so these now set `draft: true`. Filling a component's `.11tydata.json5` and deleting that one line publishes its page.

**Build now emits 3 checklist pages** (accordion, breadcrumbs, tab) instead of 31, with zero placeholder text in the output.

## The dependencies block rendered nowhere

18 component pages declared a dependency list, but `layouts/component.njk` had no matching block, so `partials/dependencies.njk` was orphaned and every list was dead content.

The block now sits after Events. Its heading lives in the partial rather than the layout, so pages with no dependencies emit no bare, empty `<h2>`.

Turning the partial on exposed two defects in code that had never run: blank lines and indentation made the markdown processor wrap its output in stray `<p>` tags, splitting the `<ul>`; and `table/index.md` declared its two dependencies as one comma-joined string, rendering as a single broken list item.

## Every dependency list was wrong or missing

Validated against `@nysds/components` `develop` @ `b2bf800b`.

**`package.json` is not the source of truth.** Story files import siblings for demos and `package.json` follows them, so it overstates the runtime graph. The truth is what `packages/nys-{name}/src/nys-{name}.ts` imports.

- **8 lists were wrong.** Most understated: the form controls all quietly import `nys-errormessage` and `nys-label`, and textinput adds `nys-button`. Checkbox listed one of its four. Two were wrong the other way — stepper imports nothing, textarea does not import `nys-icon`.
- **7 pages had no list** despite having dependencies: breadcrumbs, combobox, globalfooter, globalheader, radiobutton, unavheader, iconlist.
- **Vertical nav** listed `<nys-accordionitem>` and `<nys-verticalnavgroup>` and omitted `<nys-icon>`. `nys-verticalnav.ts` imports `nys-accordion` and `nys-icon`; verticalnavgroup ships inside the vertical nav package itself.
- Card and process list import nothing, so neither gets a section.

**35 component pages validate against real imports with 0 mismatches.**

Also rewrote the empty-state copy, which had been unreachable. It pitched the component proposal process directly above the "Suggest a New Component" section that does the same thing.

## Page titles

#528 dropped `{{ site.title }}` to stop the home page rendering "The New York State Design System - New York State Design System". That also stripped the site name from every other page's tab and search result.

The home page now carries its own title alone; everything else appends the site name. A page with no title of its own gets the site name rather than an empty `<title>` — the previous markup would have emitted nothing at all for anything setting `section: home` (WCAG 2.4.2).

| | before | after |
|---|---|---|
| `/` | The New York State Design System - New York State Design System | The New York State Design System |
| `/components/card/` | Card | Card - New York State Design System |

## Verification

Production build to a clean output directory:

- 3 a11y-tests pages built, 0 pages containing scaffold text
- 0 empty `<title>` elements
- 35 component pages validated against real imports, 0 mismatches
- Build passes, 156 pages

There is no test suite in this repo (`npm test` is the npm placeholder), so the build plus these assertions is the full verification.

## Not included

The four `@nysds/components` packages that declare deps their source never imports are an upstream fix — noted in #551 for the core repo. Note that nysds PR ITS-HCD/nysds#1781 went the other direction, editing `.stories.ts` files to match `package.json`, so any doc tooling pointed at `package.json` will reproduce them.