### PR TITLE
[WIP] Adds A11y Test+Build: Dialog (modal)

### DIFF
--- a/src/assets/nysa11y/breadcrumb-custom.js
+++ b/src/assets/nysa11y/breadcrumb-custom.js
@@ -1,72 +1,64 @@
 /**
- * NYSA11y Breadcrumb
+ * NYSA11y Breadcrumb (custom)
  * Path: /assets/nysa11y/breadcrumb-custom.js
- * Depends on /assets/nysa11y/breadcrub-custom.css
+ * Depends on /assets/nysa11y/breadcrumb-custom.css
  */
-class Breadcrumb {
-  // Private fields for internal state and DOM elements
-  #container;
-  #navElement;
-  #revealer;
-  #intermediateItems;
-  #observer;
-  #isButtonClicked = false;
+const nysa11y = window.nysa11y || {};
 
-  /**
-   * Initializes the Breadcrumb instance.
-   * @param {Object} options Configuration options.
-   * @param {HTMLElement} options.container The root <nav> element of the breadcrumb component.
-   */
+class Breadcrumb {
+  #selectorRoot = 'nav[data-component="breadcrumb"]';
+  #selectorRevealer = '[data-part="revealer"]';
+  #selectorIntermediate = ".intermediate";
+  #selectorButton = "button";
+  #selectorLink = "a";
+
   constructor(options = {}) {
-    this.#container = options.container || document;
-    this.#init();
+    this.container = options.container || document;
+    this.init();
   }
 
-  /**
-   * Sets up the component's elements, event listeners, and initial state.
-   */
-  #init() {
-    this.#navElement = this.#container.querySelector('nav[data-component="breadcrumb"]') || this.#container;
-    this.#revealer = this.#navElement.querySelector('[data-part="revealer"]');
-    this.#intermediateItems = this.#navElement.querySelectorAll(".intermediate");
+  init() {
+    const roots = this.container.querySelectorAll(this.#selectorRoot);
+    if (!roots.length) return;
 
-    if (!this.#revealer) {
-      console.error(
-        `Breadcrumb component (ID: ${this.#navElement.id || "unknown"}) is missing 'data-part="revealer"' element.`,
-      );
+    roots.forEach((rootEl) => {
+      this.#setupBreadcrumb(rootEl);
+    });
+  }
+
+  #setupBreadcrumb = (rootEl) => {
+    const revealer = rootEl.querySelector(this.#selectorRevealer);
+    if (!revealer) {
+      console.error(`Breadcrumb component (ID: ${rootEl.id || "unknown"}) is missing 'data-part="revealer"' element.`);
       return;
     }
 
-    // Bind the event listener to the revealer button
-    const revealerButton = this.#revealer.querySelector("button");
-    if (revealerButton) {
-      revealerButton.addEventListener("click", () => {
-        this.#isButtonClicked = true;
-        // Mutate DOM
-        this.maximize();
-      });
+    const button = revealer.querySelector(this.#selectorButton);
+    if (button) {
+      button.removeEventListener("click", this.#handleRevealerClick);
+      button.addEventListener("click", this.#handleRevealerClick);
     }
 
-    // Use a MutationObserver to watch for changes to the 'data-state' attribute
-    this.#observer = new MutationObserver((mutationsList) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "attributes" && mutation.attributeName === "data-state") {
-          this.render();
-        }
-      }
+    // Disconnect any existing observer on this element
+    if (rootEl.__nysa11yBreadcrumbObserver) {
+      rootEl.__nysa11yBreadcrumbObserver.disconnect();
+    }
 
-      if (this.#isButtonClicked) {
-        // Reset flag immediately
-        this.#isButtonClicked = false;
-        // Perform action only if button triggered.
-        // Why? Because rerender has to complete before we move focus.
-        // Why are we managing focus? Because the focused element, the button,
-        // is about to be `display:none`, and we MUST NOT lose focus back to <body>.
+    // Create a new MutationObserver and stash it on the element expando
+    const observer = new MutationObserver((mutationsList) => {
+      mutationsList.forEach((mutation) => {
+        if (mutation.type === "attributes" && mutation.attributeName === "data-state") {
+          this.#render(rootEl);
+        }
+      });
+
+      if (rootEl.__nysa11yIsButtonClicked) {
+        rootEl.__nysa11yIsButtonClicked = false;
+
         requestAnimationFrame(() => {
-          // When changing to 'max', focus on the zeroth intermediate item
-          if (this.#intermediateItems.length > 0) {
-            // Find a focusable element within the first intermediate item (e.g., a link)
-            const focusableElement = this.#intermediateItems[0].querySelector("a");
+          const intermediateItems = rootEl.querySelectorAll(this.#selectorIntermediate);
+          if (intermediateItems.length > 0) {
+            const focusableElement = intermediateItems[0].querySelector(this.#selectorLink);
             if (focusableElement) {
               focusableElement.focus();
             }
@@ -75,59 +67,55 @@ class Breadcrumb {
       }
     });
 
-    this.#observer.observe(this.#navElement, { attributes: true });
+    observer.observe(rootEl, { attributes: true });
+    rootEl.__nysa11yBreadcrumbObserver = observer;
 
-    // Initial render and make the nav visible
-    this.render();
-    this.#navElement.style.display = "block";
-  }
+    // Initial render and display
+    this.#render(rootEl);
+    rootEl.style.display = "block";
+  };
 
-  /**
-   * Sets 'data-state' to 'max'.
-   */
-  maximize() {
-    this.#navElement.setAttribute("data-state", "max");
-  }
+  #handleRevealerClick = (event) => {
+    const button = event.currentTarget;
+    const rootEl = button.closest(this.#selectorRoot);
+    if (!rootEl) return;
 
-  /**
-   * Sets 'data-state' to 'min'.
-   */
-  minimize() {
-    this.#navElement.setAttribute("data-state", "min");
-  }
+    rootEl.__nysa11yIsButtonClicked = true;
+    this.maximize(rootEl);
+  };
 
-  /**
-   * Renders the component based on the current 'data-state'.
-   */
-  render() {
-    const state = this.#navElement.getAttribute("data-state");
+  #render = (rootEl) => {
+    const state = rootEl.getAttribute("data-state");
+    const intermediateItems = rootEl.querySelectorAll(this.#selectorIntermediate);
+    const revealer = rootEl.querySelector(this.#selectorRevealer);
+    if (!revealer) return;
 
     if (state === "min") {
-      this.#intermediateItems.forEach((item) => {
+      intermediateItems.forEach((item) => {
         item.style.display = "none";
       });
-      this.#revealer.style.display = "flex";
+      revealer.style.display = "flex";
     } else if (state === "max") {
-      this.#intermediateItems.forEach((item) => {
+      intermediateItems.forEach((item) => {
         item.style.display = "flex";
       });
-      this.#revealer.style.display = "none";
+      revealer.style.display = "none";
     } else {
       console.warn(`Invalid 'data-state' value: ${state}`);
     }
+  };
+
+  maximize(rootEl) {
+    rootEl.setAttribute("data-state", "max");
   }
 
-  /**
-   * Static method to initialize all matching nav elements on the page.
-   */
-  static initializeAll() {
-    document.querySelectorAll('nav[data-component="breadcrumb"]').forEach((navElement) => {
-      new Breadcrumb({ container: navElement });
-    });
+  minimize(rootEl) {
+    rootEl.setAttribute("data-state", "min");
   }
 }
 
-// Initialize all breadcrumbs when the DOM is ready
+nysa11y.Breadcrumb = Breadcrumb;
+
 document.addEventListener("DOMContentLoaded", () => {
-  Breadcrumb.initializeAll();
+  new nysa11y.Breadcrumb();
 });

--- a/src/assets/nysa11y/button-native.css
+++ b/src/assets/nysa11y/button-native.css
@@ -1,0 +1,74 @@
+/**
+ * NYSA11y Button
+ * <button>
+ * Work in Progress, not complete.
+ * Goal: wrap to two lines without increase from default height
+ */
+@layer nysa11y {
+    body:has(.nysa11y) {
+        button.nysa11y.button[data-component="button"][data-html="native"] {
+            *,
+            *:before,
+            *:after {
+                box-sizing: border-box;
+            }
+            font-family: var(
+                --nys-font-family-sans,
+                "Proxima Nova",
+                -apple-system,
+                "BlinkMacSystemFont",
+                "Segoe UI",
+                "Roboto",
+                "Helvetica",
+                "Arial",
+                sans-serif,
+                "Apple Color Emoji",
+                "Segoe UI Emoji",
+                "Segoe UI Symbol"
+            );
+            align-items: center;
+            background-color: var(--nys-button-background-color, #154973);
+            border-color: var(--nys-button-border-color, transparent);
+            border-radius: var(--nys-radius-xl, 12px);
+            border-width: var(--nys-border-width-md, 2px);
+            color: var(--nys-button-color, #ffffff);
+            display: flex;
+            font-size: 1rem;
+            font-weight: var(--nys-font-weight-semibold, 600);
+            line-height: 1;
+            min-height: var(--nys-size-600, 3rem);
+            padding-block: 0.25rem;
+            padding-inline: 1.125rem;
+            &.small {
+                min-height: 2.5rem;
+            }
+            &.large {
+                min-height: 3.5rem;
+            }
+            &:focus-visible {
+                outline: solid var(--nys-border-width-md, 2px) var(--nys-color-focus, #004dd1);
+                outline-offset: var(--nys-border-width-md, 2px);
+            }
+            &.ghost {
+                background-color: transparent;
+                color: var(--nys-button-color, #1b1b1b);
+            }
+            &:hover {
+                background-color: var(--nys-button-background-color--hover, #0e324f);
+                &.ghost {
+                    background-color: var(--nys-color-black-transparent-100, #0000001a);
+                }
+            }
+            &:active {
+                background-color: var(--nys-button-background-color--active, #081b2b);
+                &.ghost {
+                    background-color: var(--nys-color-black-transparent-200, #00000033);
+                }
+            }
+            & .button__accname {
+                /* magic number */
+                /*margin-block-start: calc(0.125rem * -1);*/
+            }
+        }
+    }
+}

--- a/src/assets/nysa11y/dialog-native.css
+++ b/src/assets/nysa11y/dialog-native.css
@@ -2,12 +2,17 @@
  * NYSA11y Dialog (native modal)
  * Path: /assets/nysa11y/dialog-native.css
  * Depends on /assets/nysa11y/dialog-native.js
- * All uses of `!important` are defensive.
  */
 @layer nysa11y {
+    html:has(dialog.nysa11y[open]) {
+        /* prevent `body` scrolling */
+        overflow: hidden;
+        scrollbar-gutter: stable;
+    }
     body:has(.nysa11y) {
-        font-size: 16px; /* 1.0rem */
+        font-size: 16px; /* Set the 1.0rem baseline */
         dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
+            --nysa11y-dialog-min-usable-height: 4.5rem;
             *,
             *:before,
             *:after {
@@ -28,9 +33,14 @@
                 "Segoe UI Symbol"
             );
             border-radius: var(--nys-radius-lg, 0.5rem);
-            border: var(--nys-color-neutral-200, #bec0c1), 1px solid;
+            border:
+                var(--nys-color-neutral-200, #bec0c1),
+                1px solid;
             color: var(--nys-color-text, #1b1b1b);
             font-size: 1rem;
+            min-height: var(--nysa11y-dialog-min-usable-height);
+            overflow: hidden; /* prevent `body` scrolling */
+            overscroll-behavior: contain; /* prevent `body` scrolling */
             padding: 1.5rem;
             width: var(--nysa11y-dialog-width);
 
@@ -42,6 +52,12 @@
 
             &::backdrop {
                 background-color: var(--nys-color-black-transparent-700, rgba(27, 27, 27, 0.7));
+                overflow: hidden; /* prevent `body` scrolling */
+                overscroll-behavior: contain; /* prevent `body` scrolling */
+            }
+
+            &:has(main:not(:empty)) {
+                min-height: 18rem;
             }
 
             & header {
@@ -60,25 +76,22 @@
                     & h1 {
                         border-radius: var(--nys-radius-lg, 0.5rem);
                         display: inline-flex;
-                        font-size: 1.5rem !important;
-                        font-weight: 700 !important;
-                        line-height: inherit !important;
-                        margin-block: 0.5rem 0 !important;
+                        font-size: 1.5rem !important; /* defensive */
+                        font-weight: 700 !important; /* defensive */
+                        line-height: inherit !important; /* defensive */
+                        margin-block: 0.5rem 0 !important; /* defensive */
                         &:focus {
-                          outline: solid var(--nys-border-width-md, 2px) var(--nys-color-focus, #004dd1);
-                          outline-offset: var(--nys-border-width-md, 6px);
+                            outline: solid var(--nys-border-width-md, 2px) var(--nys-color-focus, #004dd1);
+                            outline-offset: var(--nys-border-width-md, 6px);
                         }
                     }
                 }
+                /* Modification of the `ghost` button style
+                   to better fit this usage */
                 & [data-part="exit"] {
-                    align-items: center;
-                    background-color: transparent;
-                    border-radius: 0.75rem;
                     border: 1px solid transparent;
-                    color: inherit;
                     display: flex;
                     font-size: 0.75rem;
-                    font-weight: 600;
                     gap: 0.25rem;
                     grid-area: close;
                     min-height: 2.5rem;
@@ -96,6 +109,8 @@
                         background-color: var(--nys-color-black-transparent-200, #00000033);
                     }
                 }
+                /* `mark` communicates that text is "highlighted,"
+                    to set it off from body text */
                 & mark {
                     background-color: transparent;
                     font-size: var(--nys-font-size-lg, 1.125rem);
@@ -103,6 +118,16 @@
                     grid-area: subtitle;
                     line-height: var(--nys-font-lineheight-body-lg, 1.75rem);
                 }
+            }
+
+            & main {
+                flex-grow: 1;
+                overflow: auto;
+                &:not(:empty) {
+                    min-height: var(--nysa11y-dialog-min-usable-height);
+                }
+                /* better accommodate focus ring of side-aligned focusable elements */
+                padding: 1px;
             }
 
             & footer {
@@ -116,35 +141,35 @@
     @media (max-width: 479px) {
         body:has(.nysa11y) {
             dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
-            --nysa11y-dialog-width: 90vw;
+                --nysa11y-dialog-width: 90vw;
             }
         }
     }
     @media (min-width: 480px) {
         body:has(.nysa11y) {
             dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
-              --nysa11y-dialog-width: 85vw; /* 439px */
+                --nysa11y-dialog-width: 85vw;
             }
         }
     }
     @media (min-width: 768px) {
         body:has(.nysa11y) {
             dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
-              --nysa11y-dialog-width: 80vw; /* 600px */
+                --nysa11y-dialog-width: 80vw;
             }
         }
     }
     @media (min-width: 1024px) {
         body:has(.nysa11y) {
             dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
-              --nysa11y-dialog-width: 75vw; /* 752px */
+                --nysa11y-dialog-width: 75vw;
             }
         }
     }
     @media (min-width: 1280px) {
         body:has(.nysa11y) {
             dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
-              --nysa11y-dialog-width: 70vw; /* 840px */
+                --nysa11y-dialog-width: 70vw;
             }
         }
     }

--- a/src/assets/nysa11y/dialog-native.css
+++ b/src/assets/nysa11y/dialog-native.css
@@ -1,0 +1,151 @@
+/**
+ * NYSA11y Dialog (native modal)
+ * Path: /assets/nysa11y/dialog-native.css
+ * Depends on /assets/nysa11y/dialog-native.js
+ * All uses of `!important` are defensive.
+ */
+@layer nysa11y {
+    body:has(.nysa11y) {
+        font-size: 16px; /* 1.0rem */
+        dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
+            *,
+            *:before,
+            *:after {
+                box-sizing: border-box;
+            }
+            font-family: var(
+                --nys-font-family-sans,
+                "Proxima Nova",
+                -apple-system,
+                "BlinkMacSystemFont",
+                "Segoe UI",
+                "Roboto",
+                "Helvetica",
+                "Arial",
+                sans-serif,
+                "Apple Color Emoji",
+                "Segoe UI Emoji",
+                "Segoe UI Symbol"
+            );
+            border-radius: var(--nys-radius-lg, 0.5rem);
+            border: var(--nys-color-neutral-200, #bec0c1), 1px solid;
+            color: var(--nys-color-text, #1b1b1b);
+            font-size: 1rem;
+            padding: 1.5rem;
+            width: var(--nysa11y-dialog-width);
+
+            &[open] {
+                display: flex;
+                flex-direction: column;
+                gap: var(--nys-space-300, 1.5rem);
+            }
+
+            &::backdrop {
+                background-color: var(--nys-color-black-transparent-700, rgba(27, 27, 27, 0.7));
+            }
+
+            & header {
+                align-items: start;
+                display: grid;
+                gap: var(--nys-space-100, 0.5rem);
+                grid-template-areas:
+                    "title close"
+                    "subtitle subtitle";
+                grid-template-columns: 1fr auto;
+                grid-template-rows: auto auto;
+                justify-content: space-between;
+                line-height: 1;
+                & .heading {
+                    grid-area: title;
+                    & h1 {
+                        border-radius: var(--nys-radius-lg, 0.5rem);
+                        display: inline-flex;
+                        font-size: 1.5rem !important;
+                        font-weight: 700 !important;
+                        line-height: inherit !important;
+                        margin-block: 0.5rem 0 !important;
+                        &:focus {
+                          outline: solid var(--nys-border-width-md, 2px) var(--nys-color-focus, #004dd1);
+                          outline-offset: var(--nys-border-width-md, 6px);
+                        }
+                    }
+                }
+                & [data-part="exit"] {
+                    align-items: center;
+                    background-color: transparent;
+                    border-radius: 0.75rem;
+                    border: 1px solid transparent;
+                    color: inherit;
+                    display: flex;
+                    font-size: 0.75rem;
+                    font-weight: 600;
+                    gap: 0.25rem;
+                    grid-area: close;
+                    min-height: 2.5rem;
+                    padding-block: 0.65rem;
+                    padding-inline: 0.75rem;
+                    &::after {
+                        content: "\2715" / "";
+                        font-size: 1.5rem;
+                        line-height: 0.75;
+                    }
+                    &:hover {
+                        background-color: var(--nys-color-black-transparent-100, #0000001a);
+                    }
+                    &:active {
+                        background-color: var(--nys-color-black-transparent-200, #00000033);
+                    }
+                }
+                & mark {
+                    background-color: transparent;
+                    font-size: var(--nys-font-size-lg, 1.125rem);
+                    font-weight: var(--nys-font-weight-semibold, 600);
+                    grid-area: subtitle;
+                    line-height: var(--nys-font-lineheight-body-lg, 1.75rem);
+                }
+            }
+
+            & footer {
+                display: flex;
+                flex-direction: row;
+                gap: var(--nys-space-250, 1.25rem);
+                justify-content: end;
+            }
+        }
+    }
+    @media (max-width: 479px) {
+        body:has(.nysa11y) {
+            dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
+            --nysa11y-dialog-width: 90vw;
+            }
+        }
+    }
+    @media (min-width: 480px) {
+        body:has(.nysa11y) {
+            dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
+              --nysa11y-dialog-width: 85vw; /* 439px */
+            }
+        }
+    }
+    @media (min-width: 768px) {
+        body:has(.nysa11y) {
+            dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
+              --nysa11y-dialog-width: 80vw; /* 600px */
+            }
+        }
+    }
+    @media (min-width: 1024px) {
+        body:has(.nysa11y) {
+            dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
+              --nysa11y-dialog-width: 75vw; /* 752px */
+            }
+        }
+    }
+    @media (min-width: 1280px) {
+        body:has(.nysa11y) {
+            dialog.nysa11y.dialog[data-component="dialog"][data-html="native"] {
+              --nysa11y-dialog-width: 70vw; /* 840px */
+            }
+        }
+    }
+}

--- a/src/assets/nysa11y/dialog-native.js
+++ b/src/assets/nysa11y/dialog-native.js
@@ -38,12 +38,14 @@ class Dialog {
   enter(dialogEl) {
     if (!dialogEl || typeof dialogEl.showModal !== "function") return;
     if (dialogEl.open) return;
+    /* invoke the native method to open `dialog` with modality */
     dialogEl.showModal();
   }
 
   exit(dialogEl) {
     if (!dialogEl || typeof dialogEl.close !== "function") return;
     if (!dialogEl.open) return;
+    /* invoke the native method to close `dialog` */
     dialogEl.close();
   }
 
@@ -65,13 +67,12 @@ class Dialog {
     if (!dialogEl) return;
     this.exit(dialogEl);
   };
-
 }
 
 nysa11y.Dialog = Dialog;
 
-window.exitDialog = (callback) => {
-  const openDialog = document.querySelector('dialog[open]');
+window.exitDialog = () => {
+  const openDialog = document.querySelector("dialog[open]");
   if (openDialog && nysa11y.dialogInstance) {
     nysa11y.dialogInstance.exit(openDialog);
   }

--- a/src/assets/nysa11y/dialog-native.js
+++ b/src/assets/nysa11y/dialog-native.js
@@ -1,0 +1,82 @@
+/**
+ * NYSA11y Dialog (native invocation)
+ * Path: /assets/nysa11y/dialog-native.js
+ * Depends on /assets/nysa11y/dialog-native.css
+ */
+const nysa11y = window.nysa11y || {};
+
+class Dialog {
+  #selectorRoot = '[data-component="dialog"].nysa11y';
+  #selectorTrigger = "[data-nysa11y-dialog]";
+  #selectorExit = '[data-part="exit"]';
+
+  constructor(options = {}) {
+    this.container = options.container || document;
+    this.init();
+  }
+
+  init() {
+    const triggers = this.container.querySelectorAll(this.#selectorTrigger);
+    const dialogs = this.container.querySelectorAll(this.#selectorRoot);
+
+    if (!triggers.length && !dialogs.length) return;
+
+    triggers.forEach((trigger) => {
+      trigger.removeEventListener("click", this.#handleTriggerClick);
+      trigger.addEventListener("click", this.#handleTriggerClick);
+    });
+
+    dialogs.forEach((dialogEl) => {
+      const exits = dialogEl.querySelectorAll(this.#selectorExit);
+      exits.forEach((exitBtn) => {
+        exitBtn.removeEventListener("click", this.#handleExitClick);
+        exitBtn.addEventListener("click", this.#handleExitClick);
+      });
+    });
+  }
+
+  enter(dialogEl) {
+    if (!dialogEl || typeof dialogEl.showModal !== "function") return;
+    if (dialogEl.open) return;
+    dialogEl.showModal();
+  }
+
+  exit(dialogEl) {
+    if (!dialogEl || typeof dialogEl.close !== "function") return;
+    if (!dialogEl.open) return;
+    dialogEl.close();
+  }
+
+  #handleTriggerClick = (event) => {
+    const trigger = event.currentTarget;
+    const selector = trigger.getAttribute("data-nysa11y-dialog");
+    if (!selector) return;
+    const dialogEl = this.container.querySelector(selector);
+    if (!dialogEl) {
+      console.error(`Error: The "${selector}" dialog is not found.`);
+      return;
+    }
+    this.enter(dialogEl);
+  };
+
+  #handleExitClick = (event) => {
+    const exitBtn = event.currentTarget;
+    const dialogEl = exitBtn.closest(this.#selectorRoot);
+    if (!dialogEl) return;
+    this.exit(dialogEl);
+  };
+
+}
+
+nysa11y.Dialog = Dialog;
+
+window.exitDialog = (callback) => {
+  const openDialog = document.querySelector('dialog[open]');
+  if (openDialog && nysa11y.dialogInstance) {
+    nysa11y.dialogInstance.exit(openDialog);
+  }
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  nysa11y.dialogInstance = new nysa11y.Dialog();
+});

--- a/src/content/components/modal/a11y-build.njk
+++ b/src/content/components/modal/a11y-build.njk
@@ -230,7 +230,7 @@ Design, test, and build for scenarios in which a dialog may fill an entire scree
 <p>
     A proper modal dialog <strong>must</strong> pull focus into itself upon opening.
     It is essential that this happen, and likewise that while the dialog remains open focus be almost entirely trapped within.
-    As described in the corresponding <a href="../accessibility-test/">Tests</a>, in the majority of cases <code>tabindex</code> will remain inside the dialog, wrapping between the top and bottom of the dialog's user interface.
+    As described in the corresponding <a href="../accessibility-tests/">Modal Accessibility Checklist</a>, in the majority of cases <code>tabindex</code> will remain inside the dialog, wrapping between the top and bottom of the dialog's user interface.
 </p>
 <p>
     Let's consider a scenario in which a user activates a button in main content to open a modal dialog.

--- a/src/content/components/modal/a11y-build.njk
+++ b/src/content/components/modal/a11y-build.njk
@@ -1,20 +1,20 @@
 ---
 permalink: /components/modal/accessibility-build/
 title: Build Accessibly
-title_h1: Build an Accessible Modal
-description: How to code an accessible modal.
+title_h1: Build an Accessible Modal Dialog
+description: How to code an accessible modal dialog.
 image: /assets/img/components/modal.svg
-image_alt: An illustration of an modal
+image_alt: An illustration of a modal dialog
 image_header: /assets/img/components/modal-header.svg
 stable: true
 parent: Modal
 navOrder: 2
 extra_css:
+  - "/assets/nysa11y/button-native.css"
   - "/assets/nysa11y/dialog-native.css"
-  - "/assets/nysa11y/dialog-custom.css"
   - "/assets/nysa11y/divider-native.css"
 extra_js:
-  - "/assets/nysa11y/dialog-custom.js"
+  - "/assets/nysa11y/dialog-native.js"
 ---
 
 {% extends "layouts/component-a11y-build.njk" %}
@@ -25,25 +25,97 @@ extra_js:
 {% block Alternatives %}
 <div class="solution">
     <div class="card">
-        <h3>Style the native HTML <code class="element">details</code> element</h3>
+        <h3>Configure the native HTML <code class="element">dialog</code> element</h3>
         <p>
             <mark class="subhead strong">When to use</mark>
             If your team has source-level control over UI code,
-            wants to avoid error-prone semantics programming,
+            wants to avoid error-prone recreation of semantics, z-index, backdrop, and focus management,
             and has no hard requirements in excess of what native HTML provides,
-            then the <code class="element">details</code> element is a great option
-            that has built-in accessibility and is effectively unbreakable.
+            then the <code class="element">dialog</code> element invoked as a modal is the number one recommendation.
         </p>
         {% include "partials/a11y-rely-checks.njk" %}
     </div>
 
     {% block HTMLNative %}
     {% set preview %}
-
+<button type="button"
+        class="nysa11y button"
+        data-component="button"
+        data-html="native"
+        data-nysa11y-dialog="#myModal">Visit NYS</button>
+<dialog aria-labelledby="zoo"
+        class="nysa11y dialog"
+        data-component="dialog"
+        data-html="native"
+        id="myModal">
+    <header>
+        <div class="heading">
+            <h1 autofocus tabindex="-1" id="zoo">Visit New York State</h1>
+        </div>
+        <button type="button" data-part="exit">Close</button>
+        <mark class="subhead">Expand your horizons by exploring ours!</mark>
+    </header>
+    <main aria-label="dialog content">
+        <p>
+            This is a main content region.
+            When the <code class="element">dialog</code> opens do you perceive
+            <em>focus</em> strongly evident on the heading?
+        </p>
+        <p>
+            New York State is <a href="https://www.iloveny.com/things-to-do/history/" target="_blank">historic</a>.
+            It's untamed. It's iconic. But more importantly, it's anything you want it to be.
+            From the lights of <a href="https://www.iloveny.com/places-to-go/new-york-city/city-guide-new-york-city/" target="_blank">Times Square</a>
+            to the mists of <a href="https://www.iloveny.com/places-to-go/niagara/spotlight-buffalo-niagara-falls/" target="_blank">Niagara Falls</a>,
+            <a href="https://www.iloveny.com/places-to-go/adirondacks/city-guide-lake-placid/" target="_blank">Lake Placid</a>'s Olympic legacy to
+            <a href="https://www.iloveny.com/places-to-go/central/spotlight-cooperstown/" target="_blank">Cooperstown</a>'s baseball roots,
+            <a href="https://www.iloveny.com/places-to-go/capital-saratoga/albany-city-guide/" target="_blank">Albany's</a> 400-year history to
+            <a href="https://www.iloveny.com/places-to-go/chautauqua-allegheny/jamestown-spotlight/" target="_blank">Jamestown</a>'s comedy treasures, the castles of the
+            <a href="https://www.iloveny.com/places-to-go/1000-islands/" target="_blank">Thousand Islands</a> to
+            <a href="https://www.iloveny.com/places-to-go/long-island/spotlight-long-island/" target="_blank">Long Island</a>'s
+            <a href="https://www.iloveny.com/listing/gold-coast-mansions-of-long-island/14992/" target="_blank">Gold Coast mansions</a>, the
+            <a href="https://www.iloveny.com/places-to-go/hudson-valley/" target="_blank">Hudson Valley</a>'s inspiring landscapes to the
+            <a href="https://www.iloveny.com/places-to-go/catskills/" target="_blank">Catskills'</a> sweeping mountain views and stunning
+            <a href="https://www.iloveny.com/places-to-go/finger-lakes/" target="_blank">Finger Lakes</a> wine country—there’s something for everyone.
+        </p>
+        <div>
+            <nys-select label="Keyboard interaction test">
+                <span slot="description">
+                    Activate the <code class="element">select</code> element to open it,
+                    but before making a selection dismiss it with the <kbd>Escape</kbd> key.
+                    Ensure this action affects only the <code class="element">select</code>,
+                    and the <code class="element">dialog</code> remains open.
+                    Once the <code class="element">select</code> closes,
+                    activate <kbd>Escape</kbd> again.
+                    The <code class="element">dialog</code> should then close.
+                </span>
+                <option>One</option>
+                <option>Two</option>
+                <option>Three</option>
+                <option>4,567,890</option>
+            </nys-select>
+        </div>
+    </main>
+    <footer aria-label="dialog actions">
+        <button data-component="button"
+                data-html="native"
+                class="nysa11y button ghost"
+                type="button"
+                onClick="alert('hey!');">
+            <span class="button__accname">Not now</span>
+        </button>
+        <button data-component="button"
+                data-html="native"
+                class="nysa11y button"
+                type="button"
+                onClick="exitDialog();">
+            <span class="button__accname">Update</span>
+        </button>
+    </footer>
+</dialog>
     {% endset %}
     {% set accordionLabel = "HTML" %}
     {% set code = preview %}
-    {% set codeExpanded = true %}
+    {% set codeExpanded = false %}
     {% set codeLanguage = "html" %}
     {% set showTip = false %}
     {% include "partials/code-preview.njk" %}
@@ -58,55 +130,10 @@ extra_js:
     {% set codeLanguage = "css" %}
     {% include "partials/code-preview.njk" %}
     {% endblock %}{# CSSNative #}
-</div>
 
-<hr class="nysa11y divider" data-component="divider" data-html="native">
-
-<div class="solution">
-    <div class="card">
-        <h3>Build a custom modal dialog component</h3>
-        <p>
-            <mark class="subhead strong">When to use</mark>
-            If your team has source-level control over UI code,
-            but DOES have a hard requirement not provided by native HTML,
-            you may choose to build a custom modal dialog.
-            Or perhaps your legacy component has been flagged for remediation
-            and you need a high quality reference.
-            This custom example recreates the accessibility built into the
-            NYSDS Modal.
-            See the
-            <a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/" target="_blank">W3C APG Dialog (Modal) Pattern</a>
-            for more involved implementations.
-        </p>
-        {% include "partials/a11y-rely-checks.njk" %}
-    </div>
-
-    {% block HTMLCustom %}
-    {% set preview %}
-
-    {% endset %}
-    {% set accordionLabel = "HTML" %}
-    {% set code = preview %}
-    {% set codeExpanded = true %}
-    {% set codeLanguage = "html" %}
-    {% set showTip = false %}
-    {% include "partials/code-preview.njk" %}
-    {% endblock %}{# HTMLCustom #}
-
-    {% block CSSCustom %}
+    {% block JSNative %}
     {% set code %}
-    {% include "../../../assets/nysa11y/dialog-custom.css" %}
-    {% endset %}
-    {% set accordionLabel = "CSS" %}
-    {% set codeExpanded = false %}
-    {% set codeLanguage = "css" %}
-    {% include "partials/code-preview.njk" %}
-    {% endblock %}{# CSSCustom #}
-
-
-    {% block JSCustom %}
-    {% set code %}
-    {% include "../../../assets/nysa11y/dialog-custom.js" %}
+    {% include "../../../assets/nysa11y/dialog-native.js" %}
     {% endset %}
     {% set accordionLabel = "JavaScript" %}
     {% set codeExpanded = false %}
@@ -114,162 +141,155 @@ extra_js:
     {% include "partials/code-preview.njk" %}
     {% endblock %}{# JSCustom #}
 </div>
+
 {% endblock %}{# Alternatives #}
 
 {% block AboutThisPattern %}
 <p>
-    The dialog experience is a dramatic re-framing of users' context and
-focus, second only to a full page navigation. In fact, native operating
-system dialogs and early World Wide Web browser dialogs were actual new
-system or application windows displayed above the window of
-origination.
+    The dialog experience is a dramatic re-framing of users' context and focus, second only to a full page navigation.
+    In fact, native operating system dialogs and early World Wide Web browser dialogs were actual new system or application windows displayed above the window of origination.
 </p>
 <p>
-    Subsequent to the late 1990s, most web browser dialogs were faked to
-visually appear like independent windows without actually being so. The
-ensuing years of inconsistency and poor accessibility led many user
-interface experts to <a href="https://www.nngroup.com/articles/modal-nonmodal-dialog/#toc-disadvantages-of-modal-dialogs-1" target="_blank">recommend caution</a> in the use of so-called dialogs. Even
-today, designers may reasonably consider <a
-href="https://modalzmodalzmodalz.com" target="_blank">different forms</a> of disclosure
-and navigation as alternative paradigms.
+    Subsequent to the late 1990s,
+    most web browser dialogs were faked to visually appear like independent windows without actually being so.
+    The ensuing years of inconsistency and poor accessibility led many user interface experts to
+    <a href="https://www.nngroup.com/articles/modal-nonmodal-dialog/#toc-disadvantages-of-modal-dialogs-1" target="_blank">recommend caution</a>
+    in the use of so-called dialogs.
+    Even today, designers may reasonably consider
+    <a href="https://modalzmodalzmodalz.com" target="_blank">different forms</a>
+    of disclosure and navigation as alternative paradigms.
 </p>
 <p>
-    Decades of creative experimentation led to the addition of a <a
-href="https://html.spec.whatwg.org/dev/interactive-elements.html#the-dialog-element" target="_blank"><code class="element">dialog</code></a>
-element to the official HTML5 specification. This native element, which
-reached <a href="https://caniuse.com/?search=dialog" target="_blank">baseline browser
-support</a> in 2022, allows authors leeway to craft a range of user
-experiences. The HTML5 <code class="element">dialog</code> is the basis
-of the implementation shown here, and is the number one recommendation
-for any custom dialog development today. Though it is easier than ever
-to produce an accessible dialog, knowledge and care are still required
-to ensure this outcome. Let's deepen our understanding.
+    Decades of creative experimentation led to the addition of a
+    <a href="https://html.spec.whatwg.org/dev/interactive-elements.html#the-dialog-element" target="_blank"><code class="element">dialog</code></a>
+    element to the official HTML5 specification.
+    This native element, which reached <a href="https://caniuse.com/?search=dialog" target="_blank">baseline browser support</a>
+    in 2022, allows authors leeway to craft a range of user experiences.
+    The HTML5 <code class="element">dialog</code> is the basis of the implementation shown here, and is the number one recommendation for any custom dialog development today.
+    Though it is easier than ever to produce an accessible dialog, knowledge and care are still required to ensure this outcome.
+    Let's deepen our understanding.
 </p>
 <h3 id="high-level-presentation">High level presentation</h3>
 <p>
-    A dialog is a real or apparent window that presents separately from
-the primary user interface surface.
+    A dialog is a real or apparent window that presents separately from the primary user interface surface.
 </p>
 <ul>
-  <li>Visually, dialogs appear in the foreground "above" the main
-  screen</li>
-  <li>Aurally, dialogs are perceived as discrete, self-contained
-  areas</li>
-  <li>A dialog may be automatically opened and closed by an operating
-  system or application, or manually activated by the user; manual control
-  is preferred</li>
-  <li>In the majority of cases, a user will interact with dialog content
-  in order to effect an outcome that closes the dialog and moves the user
-  to the primary surface</li>
+  <li>Visually, dialogs appear in the foreground "above" the main screen</li>
+  <li>Aurally, dialogs are perceived as discrete, self-contained areas</li>
+  <li>A dialog may be automatically opened and closed by an operating system or application, or manually activated by the user; manual control is preferred</li>
+  <li>In the majority of cases, a user will interact with dialog content in order to effect an outcome that closes the dialog and moves the user to the primary surface</li>
   <li>There is no set size for dialogs</li>
-  <li>It is possible, though not recommended, for dialogs to completely
-  fill a visual viewport by default; designers should account for cases in
-  which this is actually the best user experience, for example in screen
-  magnification and mobile portrait orientation scenarios</li>
-  <li>More commonly, dialogs are presented visually as relatively small
-  boxes centrally located on screen</li>
+  <li>It is possible, though not recommended, for dialogs to completely fill a visual viewport by default; designers should account for cases in which this is actually the best user experience, for example in screen magnification and mobile portrait orientation scenarios</li>
+  <li>More commonly, dialogs are presented visually as relatively small boxes centrally located on screen</li>
 </ul>
 <h3 id="what-is-a-modal">What is a "modal"?</h3>
 <p>A "modal" is an intensification of the dialog pattern.</p>
 <ul>
-  <li>Typically the primary content "below" a modal dialog is visually
-  dimmed to varying extents; with modals, non-dialog content should be
-  literally inert, unreachable, and non-interactive</li>
-  <li>Interaction with other application or operating system interfaces is
-  substantially blocked until required actions in the modal dialog are
-  complete</li>
+  <li>Typically the primary content "below" a modal dialog is visually dimmed to varying extents; with modals, non-dialog content should be literally inert, unreachable, and non-interactive</li>
+  <li>Interaction with other application or operating system interfaces is substantially blocked until required actions in the modal dialog are complete</li>
 </ul>
 <h3 id="responsiveness">Responsiveness</h3>
 <p>
-    Like any content, a dialog should gracefully adapt to orientation
-change, mobile viewports, text size increase, and screen magnification.
-Design, test, and build for scenarios in which a dialog may fill an
-entire screen, may require scrollbars, and may accommodate a 200% font
-size increase.
+    Like any content, a dialog should gracefully adapt to orientation change, mobile viewports, text size increase, and screen magnification.
+Design, test, and build for scenarios in which a dialog may fill an entire screen, may require scrollbars, and may accommodate a 200% font size increase.
 </p>
 <h3 id="focus-movement">Focus movement</h3>
 <p>
-    Whether it is visible or not, some page element always has
-programmatic focus, even if it happens to be the
-<code class="element">body</code>, which typically has focus on page
-load. Generally any element clicked by a mouse gains focus at that
-moment.
+    Whether it is visible or not, some page element always has programmatic focus, even if it happens to be the <code class="element">body</code>, which typically has focus on page load.
+    Mouse users take note: generally any element clicked by a mouse gains focus at that moment.
 </p>
 <p>
-    A proper modal dialog <strong>must</strong> pull focus into itself
-upon opening. It is essential that this happen, and likewise that while
-the dialog remains open focus be almost entirely trapped within. As seen
-on the Test page, in the majority of cases tabindex will remain inside
-the dialog, wrapping between the top and bottom of the dialog's user
-interface.
+    A proper modal dialog <strong>must</strong> pull focus into itself upon opening.
+    It is essential that this happen, and likewise that while the dialog remains open focus be almost entirely trapped within.
+    As described in the corresponding <a href="../accessibility-test/">Tests</a>, in the majority of cases <code>tabindex</code> will remain inside the dialog, wrapping between the top and bottom of the dialog's user interface.
 </p>
 <p>
-    Let's consider a scenario in which a user activates a button in main
-content to open a modal dialog. The button interaction (whether by
-mouse, keyboard, voice command, or double-tap) sets focus on the button
-for a short period of time (miliseconds) until the dialog user interface
-is ready to gain focus. This button is the last element in main content
-to have focus and is the interaction trigger that spawns the dialog.
-Consequently when the dialog is closed, focus <strong>must</strong>
-return whence it came to this trigger button, provided the main user
-interface has not changed so dramatically that the button is no longer
-present. Failure to return focus from a dialog to its trigger is a
-severe and unfortunately common issue.
+    Let's consider a scenario in which a user activates a button in main content to open a modal dialog.
+    The button interaction (whether by mouse, keyboard, voice command, or double-tap) sets focus on the button for a short period of time (miliseconds), until the dialog user interface is ready to gain focus.
+    This button is the last element in main content to have focus and is the interaction trigger that spawns the dialog.
+    Consequently when the dialog is closed, focus <strong>must</strong> return whence it came back to this trigger button, provided the main user interface has not changed so dramatically that the button is no longer present.
+    Failure to return focus from a dialog to its trigger is a severe and unfortunately common issue.
 </p>
 <p>
-    Usefully, authors may choose exactly where focus lands in a new
-dialog. While the various considerations are beyond the scope of this
-guide (see <a
-href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction" target="_blank">Keyboard
-Interaction &rarr; Note</a> aside), one of the most effective techniques is
-to use the placement of focus to ensure the dialog's accessible name is
-immediately discovered.
+    Usefully, authors may choose exactly <a href="https://adrianroselli.com/2025/06/where-to-put-focus-when-opening-a-modal-dialog.html" target="_blank">where focus lands</a> in a new dialog.
+    While the various considerations are beyond the scope of this guide
+    (see also the <a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction" target="_blank">Keyboard Interaction &rarr; Note</a> aside),
+    one of the most effective techniques is to use the placement of focus to ensure the dialog's accessible name is immediately discovered.
 </p>
 <h3 id="an-accessible-name">An accessible name</h3>
 <p>
-    A dialog <strong>must</strong> identify itself clearly to all users
-upon opening. The best accessibility is one that works for everyone. A
-single label, title, or heading can serve all users equitably with
-minimal effort. In our example, a single <code class="element">H1</code>
-element is the visual, aural, and semantic label for the dialog by
-virtue of element choice, DOM placement, and attribute settings. In a
-browser's accessibility tree, the text content of this
-<code class="element">H1</code> is literally the <a
-href="https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/" target="_blank">accessible
-name</a> of the dialog.
+    A dialog <strong>must</strong> identify itself clearly to all users upon opening.
+    The best accessibility is one that works for everyone, preferably relying on the in-built capabilities of the web platform.
+    A single label, title, or heading can serve all users equitably with minimal effort.
+    In our example, a single <code class="element">H1</code> element is the visual, aural, and semantic label for the dialog by virtue of element choice, DOM placement, and attribute settings.
+    Across devices it consistently demands first focus, without the need for explicit JavaScript <code>.focus()</code>.
+    In a browser's accessibility tree, the text content of this <code class="element">H1</code> is literally the
+    <a href="https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/" target="_blank">accessible name</a> of the dialog.
 </p>
-<pre><code>&lt;dialog aria-labelledby=&quot;my-dialog-heading&quot;&gt;
-    &lt;h1 id=&quot;my-dialog-heading&quot; tabindex=&quot;-1&quot; autofocus&gt;My Dialog&lt;/h1&gt;
-&lt;/dialog&gt;</code></pre>
+
+{% set code %}
+<dialog aria-labelledby="my-dialog-heading">
+    <h1 id="my-dialog-heading" tabindex="-1" autofocus>My Dialog</h1>
+</dialog>
+{% endset %}
+{% set accordionLabel = "Dialog heading" %}
+{% set codeExpanded = true %}
+{% include "partials/code-preview.njk" %}
+
 <h3 id="traverse-and-close">Traverse and close</h3>
 <p>
-    Once inside a modal dialog, all content structure and interaction
-rules apply the same as on the primary surface; they are just contained
-within a (usually) smaller space. The key difference is in the
-conventions to uphold for dialog dismissal:
+    Once inside a modal dialog, all content structure and interaction rules apply the same as on the primary surface; they are just contained within a (usually) smaller space.
+    The key difference is in the conventions to uphold for dialog dismissal:
 </p>
 <ul>
-  <li>Activation of the <kbd>Escape</kbd> key <strong>must</strong> close
-  the dialog, <em>except</em> while the user interacts with a child
-  element that has its own response to <kbd>Escape</kbd>, for example, a
-  native HTML <code class="element">select</code>. However, not every user
-  has access to an <kbd>Escape</kbd> key.</li>
   <li>
-      The founders of the Accessibility program at the BBC
+      Activation of the <kbd>Escape</kbd> key <strong>must</strong> close the dialog, <em>except</em> while the user interacts with a child element that has its own response to <kbd>Escape</kbd>,
+      for example, a native HTML <code class="element">select</code>.
+      However, not every user has access to an <kbd>Escape</kbd> key.
+  </li>
+  <li>
+      The industry-leading founders of the Accessibility program at the BBC
       <a href="https://a11yquest.com/pro/guides/patterns/modal-dialog/#accessible-controls" target="_blank">advise</a>:<br>
       <q>
-          All modal dialogs <strong>must</strong> have a visible, accessible control within the dialog content, allowing the user to close the dialog; for example, a button labeled <em>Close</em> or a submit button for a dialog with a form. Do not assume that the user can press an <kbd>Escape</kbd> key or click outside the content area, for example.</q></li>
+          All modal dialogs <strong>must</strong> have a visible, accessible control within the dialog content, allowing the user to close the dialog;
+          for example, a button labeled <em>Close</em> or a submit button for a dialog with a form.
+          Do not assume that the user can press an <kbd>Escape</kbd> key or click outside the content area, for example.
+      </q>
+  </li>
 </ul>
 <h3 id="best-quality-references">Best quality references</h3>
 <p>
-    This document describes and presents nearly the simplest possible modal dialog. Considerably more is possible and may be reasonably demanded by your particular set of users. When building upon our solid foundation, you may place confidence in these particular resources:
+    This document describes and presents nearly the simplest possible modal dialog.
+    More is possible and may be reasonably demanded by your particular set of users.
+    When building upon our solid foundation, these particular resources are the best available:
 </p>
 <ul>
-  <li><a href="https://a11yquest.com/pro/guides/patterns/modal-dialog/" target="_blank">Modal Dialog</a> from A11y Quest</li>
-  <li><a href="https://www.atomica11y.com/accessible-web/dialog-modal/" target="_blank">Dialog Modal HTML</a> and <a href="https://www.atomica11y.com/accessible-design/dialog-modal/" target="_blank">Dialog Modal Design</a> from Atomic Accessibility</li>
-  <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog" target="_blank">MDN HTML <code>dialog</code> element</a> from the Mozilla Developer Network</li>
-  <li><a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/" target="_blank">Dialog (Modal) Pattern</a> from the W3C ARIA Authoring Practices Guide</li>
-  <li><a href="https://html.spec.whatwg.org/dev/interactive-elements.html#the-dialog-element" target="_blank">The dialog element</a> from HTML: The Living Standard</li>
+    <li>
+        <a href="https://a11yquest.com/pro/guides/patterns/modal-dialog/" target="_blank">Modal Dialog</a>
+        from A11y Quest (ex-BBC)
+    </li>
+    <li>
+        <a href="https://www.atomica11y.com/accessible-web/dialog-modal/" target="_blank">Dialog Modal HTML</a>
+        and
+        <a href="https://www.atomica11y.com/accessible-design/dialog-modal/" target="_blank">Dialog Modal Design</a>
+        from Atomic Accessibility
+    </li>
+    <li>
+        <a href="https://adrianroselli.com/2025/06/where-to-put-focus-when-opening-a-modal-dialog.html" target="_blank">Where to Put Focus When Opening a Modal Dialog</a>
+        from <a href="https://adrianroselli.com/bio" target="_blank">Adrian Roselli</a>
+    </li>
+    <li>
+        <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog" target="_blank">MDN HTML <code>dialog</code> element</a>
+        from the Mozilla Developer Network
+    </li>
+    <li>
+        <a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/" target="_blank">Dialog (Modal) Pattern</a>
+        from the W3C ARIA Authoring Practices Guide
+    </li>
+    <li>
+        <a href="https://html.spec.whatwg.org/dev/interactive-elements.html#the-dialog-element" target="_blank">The dialog element</a>
+        from HTML: The Living Standard
+    </li>
 </ul>
 
 {% endblock %}{# AboutThisPattern #}

--- a/src/content/components/modal/a11y-build.njk
+++ b/src/content/components/modal/a11y-build.njk
@@ -38,55 +38,56 @@ extra_js:
 
     {% block HTMLNative %}
     {% set preview %}
+<!-- This trigger button is configured (in the JavaScript file)
+     to activate a dialog that has the ID passed to `data-nysa11y-dialog` -->
 <button type="button"
         class="nysa11y button"
         data-component="button"
         data-html="native"
-        data-nysa11y-dialog="#myModal">Visit NYS</button>
-<dialog aria-labelledby="zoo"
+        data-nysa11y-dialog="#myModal">Show me places to go</button>
+
+<!-- This is the native HTML5 `dialog`.
+     It opens with modal behavior due to being invoked
+     with the native method `.showModal()` -->
+<dialog aria-labelledby="VNYS"
         class="nysa11y dialog"
         data-component="dialog"
         data-html="native"
         id="myModal">
     <header>
         <div class="heading">
-            <h1 autofocus tabindex="-1" id="zoo">Visit New York State</h1>
+            <!-- This heading is the accessible name,
+                 first focused element, and visual and aural title
+                 of the dialog. Tested across operating systems,
+                 browsers, devices, and screen readers for
+                 maximum dependability. -->
+            <h1 autofocus tabindex="-1" id="VNYS">Visit New York State</h1>
         </div>
-        <button type="button" data-part="exit">Close</button>
+        <!-- In JavaScript, activation of `data-part="exit"`
+             is wired to the native `.close()` method -->
+        <button data-part="exit"
+                data-component="button"
+                data-html="native"
+                class="nysa11y button ghost"
+                type="button">Close</button>
         <mark class="subhead">Expand your horizons by exploring ours!</mark>
     </header>
     <main aria-label="dialog content">
         <p>
-            This is a main content region.
-            When the <code class="element">dialog</code> opens do you perceive
-            <em>focus</em> strongly evident on the heading?
-        </p>
-        <p>
-            New York State is <a href="https://www.iloveny.com/things-to-do/history/" target="_blank">historic</a>.
-            It's untamed. It's iconic. But more importantly, it's anything you want it to be.
-            From the lights of <a href="https://www.iloveny.com/places-to-go/new-york-city/city-guide-new-york-city/" target="_blank">Times Square</a>
-            to the mists of <a href="https://www.iloveny.com/places-to-go/niagara/spotlight-buffalo-niagara-falls/" target="_blank">Niagara Falls</a>,
-            <a href="https://www.iloveny.com/places-to-go/adirondacks/city-guide-lake-placid/" target="_blank">Lake Placid</a>'s Olympic legacy to
-            <a href="https://www.iloveny.com/places-to-go/central/spotlight-cooperstown/" target="_blank">Cooperstown</a>'s baseball roots,
-            <a href="https://www.iloveny.com/places-to-go/capital-saratoga/albany-city-guide/" target="_blank">Albany's</a> 400-year history to
-            <a href="https://www.iloveny.com/places-to-go/chautauqua-allegheny/jamestown-spotlight/" target="_blank">Jamestown</a>'s comedy treasures, the castles of the
-            <a href="https://www.iloveny.com/places-to-go/1000-islands/" target="_blank">Thousand Islands</a> to
-            <a href="https://www.iloveny.com/places-to-go/long-island/spotlight-long-island/" target="_blank">Long Island</a>'s
-            <a href="https://www.iloveny.com/listing/gold-coast-mansions-of-long-island/14992/" target="_blank">Gold Coast mansions</a>, the
-            <a href="https://www.iloveny.com/places-to-go/hudson-valley/" target="_blank">Hudson Valley</a>'s inspiring landscapes to the
-            <a href="https://www.iloveny.com/places-to-go/catskills/" target="_blank">Catskills'</a> sweeping mountain views and stunning
-            <a href="https://www.iloveny.com/places-to-go/finger-lakes/" target="_blank">Finger Lakes</a> wine country—there’s something for everyone.
+            This is the main content region.
+            When the dialog opens do you perceive
+            <strong>focus</strong> strongly evident on the heading?
         </p>
         <div>
-            <nys-select label="Keyboard interaction test">
+            <nys-select label="Keyboard interaction test" width="md">
                 <span slot="description">
-                    Activate the <code class="element">select</code> element to open it,
+                    Activate the <code class="element">nys-select</code> component to open it,
                     but before making a selection dismiss it with the <kbd>Escape</kbd> key.
-                    Ensure this action affects only the <code class="element">select</code>,
-                    and the <code class="element">dialog</code> remains open.
-                    Once the <code class="element">select</code> closes,
+                    Ensure this action affects only the <code class="element">nys-select</code>,
+                    and the dialog remains open.
+                    Once the <code class="element">nys-select</code> closes,
                     activate <kbd>Escape</kbd> again.
-                    The <code class="element">dialog</code> should then close.
+                    The dialog should then close.
                 </span>
                 <option>One</option>
                 <option>Two</option>
@@ -94,21 +95,41 @@ extra_js:
                 <option>4,567,890</option>
             </nys-select>
         </div>
+        <hr class="nysa11y divider" data-component="divider" data-html="native">
+        <h2 aria-label="I love New York">I❤️New York</h2>
+        <p>
+            New York State is <a href="https://www.iloveny.com/things-to-do/history/" target="_blank">historic</a>.
+            It's untamed. It's iconic. But more importantly, it's anything you want it to be.
+            From the lights of <a href="https://www.iloveny.com/places-to-go/new-york-city/city-guide-new-york-city/" target="_blank">Times Square</a>
+            to the mists of <a href="https://www.iloveny.com/places-to-go/niagara/spotlight-buffalo-niagara-falls/" target="_blank">Niagara Falls</a>,
+            <a href="https://www.iloveny.com/places-to-go/adirondacks/city-guide-lake-placid/" target="_blank">Lake Placid's</a> Olympic legacy to
+            <a href="https://www.iloveny.com/places-to-go/central/spotlight-cooperstown/" target="_blank">Cooperstown's</a> baseball roots,
+            <a href="https://www.iloveny.com/places-to-go/capital-saratoga/albany-city-guide/" target="_blank">Albany's</a> 400-year history to
+            <a href="https://www.iloveny.com/places-to-go/chautauqua-allegheny/jamestown-spotlight/" target="_blank">Jamestown's</a> comedy treasures, the castles of the
+            <a href="https://www.iloveny.com/places-to-go/1000-islands/" target="_blank">Thousand Islands</a> to
+            <a href="https://www.iloveny.com/places-to-go/long-island/spotlight-long-island/" target="_blank">Long Island's</a>
+            <a href="https://www.iloveny.com/listing/gold-coast-mansions-of-long-island/14992/" target="_blank">Gold Coast mansions</a>, the
+            <a href="https://www.iloveny.com/places-to-go/hudson-valley/" target="_blank">Hudson Valley</a>'s inspiring landscapes to the
+            <a href="https://www.iloveny.com/places-to-go/catskills/" target="_blank">Catskills'</a> sweeping mountain views and stunning
+            <a href="https://www.iloveny.com/places-to-go/finger-lakes/" target="_blank">Finger Lakes</a> wine country—there's something for everyone.
+        </p>
     </main>
     <footer aria-label="dialog actions">
         <button data-component="button"
                 data-html="native"
                 class="nysa11y button ghost"
                 type="button"
-                onClick="alert('hey!');">
+                onClick="alert('Perhaps the Adirondacks will interest you?');">
             <span class="button__accname">Not now</span>
         </button>
+        <!-- In JavaScript, activation of `exitDialog()`
+             is wired to the native `.close()` method -->
         <button data-component="button"
                 data-html="native"
                 class="nysa11y button"
                 type="button"
                 onClick="exitDialog();">
-            <span class="button__accname">Update</span>
+            <span class="button__accname">Plan my trip</span>
         </button>
     </footer>
 </dialog>
@@ -186,7 +207,15 @@ extra_js:
 <p>A "modal" is an intensification of the dialog pattern.</p>
 <ul>
   <li>Typically the primary content "below" a modal dialog is visually dimmed to varying extents; with modals, non-dialog content should be literally inert, unreachable, and non-interactive</li>
-  <li>Interaction with other application or operating system interfaces is substantially blocked until required actions in the modal dialog are complete</li>
+  <li>Interaction with other application or operating system interfaces is substantially blocked, with focus held within the dialog, until required actions are complete</li>
+  <li>
+      The <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement#instance_methods" target="_blank">HTMLDialogElement Web API</a>
+      allows authors to determine modality merely by the choice of native instance method to open a dialog:
+      <ul>
+          <li><code>.show()</code> opens a <strong>non-modal</strong> dialog</li>
+          <li><code>.showModal()</code> opens a <strong>modal</strong> dialog</li>
+      </ul>
+  </li>
 </ul>
 <h3 id="responsiveness">Responsiveness</h3>
 <p>
@@ -248,20 +277,18 @@ Design, test, and build for scenarios in which a dialog may fill an entire scree
       However, not every user has access to an <kbd>Escape</kbd> key.
   </li>
   <li>
-      The industry-leading founders of the Accessibility program at the BBC
+      The BBC Accessibility program founders
       <a href="https://a11yquest.com/pro/guides/patterns/modal-dialog/#accessible-controls" target="_blank">advise</a>:<br>
-      <q>
-          All modal dialogs <strong>must</strong> have a visible, accessible control within the dialog content, allowing the user to close the dialog;
+      <q><em>All modal dialogs <strong>must</strong> have a visible, accessible control within the dialog content, allowing the user to close the dialog;
           for example, a button labeled <em>Close</em> or a submit button for a dialog with a form.
-          Do not assume that the user can press an <kbd>Escape</kbd> key or click outside the content area, for example.
-      </q>
+          Do not assume that the user can press an <kbd>Escape</kbd> key or click outside the content area, for example.</em></q>
   </li>
 </ul>
 <h3 id="best-quality-references">Best quality references</h3>
 <p>
     This document describes and presents nearly the simplest possible modal dialog.
     More is possible and may be reasonably demanded by your particular set of users.
-    When building upon our solid foundation, these particular resources are the best available:
+    When building upon our solid foundation, these resources are the best available:
 </p>
 <ul>
     <li>
@@ -280,6 +307,10 @@ Design, test, and build for scenarios in which a dialog may fill an entire scree
     </li>
     <li>
         <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog" target="_blank">MDN HTML <code>dialog</code> element</a>
+        from the Mozilla Developer Network
+    </li>
+    <li>
+        <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement" target="_blank">MDN Web APIs &rarr; HTMLDialogElement</a>
         from the Mozilla Developer Network
     </li>
     <li>

--- a/src/content/components/modal/a11y-build.njk
+++ b/src/content/components/modal/a11y-build.njk
@@ -1,0 +1,275 @@
+---
+permalink: /components/modal/accessibility-build/
+title: Build Accessibly
+title_h1: Build an Accessible Modal
+description: How to code an accessible modal.
+image: /assets/img/components/modal.svg
+image_alt: An illustration of an modal
+image_header: /assets/img/components/modal-header.svg
+stable: true
+parent: Modal
+navOrder: 2
+extra_css:
+  - "/assets/nysa11y/dialog-native.css"
+  - "/assets/nysa11y/dialog-custom.css"
+  - "/assets/nysa11y/divider-native.css"
+extra_js:
+  - "/assets/nysa11y/dialog-custom.js"
+---
+
+{% extends "layouts/component-a11y-build.njk" %}
+{# block Introduction #}
+{# block RecommendedSolution #}
+
+
+{% block Alternatives %}
+<div class="solution">
+    <div class="card">
+        <h3>Style the native HTML <code class="element">details</code> element</h3>
+        <p>
+            <mark class="subhead strong">When to use</mark>
+            If your team has source-level control over UI code,
+            wants to avoid error-prone semantics programming,
+            and has no hard requirements in excess of what native HTML provides,
+            then the <code class="element">details</code> element is a great option
+            that has built-in accessibility and is effectively unbreakable.
+        </p>
+        {% include "partials/a11y-rely-checks.njk" %}
+    </div>
+
+    {% block HTMLNative %}
+    {% set preview %}
+
+    {% endset %}
+    {% set accordionLabel = "HTML" %}
+    {% set code = preview %}
+    {% set codeExpanded = true %}
+    {% set codeLanguage = "html" %}
+    {% set showTip = false %}
+    {% include "partials/code-preview.njk" %}
+    {% endblock %}{# HTMLNative #}
+
+    {% block CSSNative %}
+    {% set code %}
+    {% include "../../../assets/nysa11y/dialog-native.css" %}
+    {% endset %}
+    {% set accordionLabel = "CSS" %}
+    {% set codeExpanded = false %}
+    {% set codeLanguage = "css" %}
+    {% include "partials/code-preview.njk" %}
+    {% endblock %}{# CSSNative #}
+</div>
+
+<hr class="nysa11y divider" data-component="divider" data-html="native">
+
+<div class="solution">
+    <div class="card">
+        <h3>Build a custom modal dialog component</h3>
+        <p>
+            <mark class="subhead strong">When to use</mark>
+            If your team has source-level control over UI code,
+            but DOES have a hard requirement not provided by native HTML,
+            you may choose to build a custom modal dialog.
+            Or perhaps your legacy component has been flagged for remediation
+            and you need a high quality reference.
+            This custom example recreates the accessibility built into the
+            NYSDS Modal.
+            See the
+            <a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/" target="_blank">W3C APG Dialog (Modal) Pattern</a>
+            for more involved implementations.
+        </p>
+        {% include "partials/a11y-rely-checks.njk" %}
+    </div>
+
+    {% block HTMLCustom %}
+    {% set preview %}
+
+    {% endset %}
+    {% set accordionLabel = "HTML" %}
+    {% set code = preview %}
+    {% set codeExpanded = true %}
+    {% set codeLanguage = "html" %}
+    {% set showTip = false %}
+    {% include "partials/code-preview.njk" %}
+    {% endblock %}{# HTMLCustom #}
+
+    {% block CSSCustom %}
+    {% set code %}
+    {% include "../../../assets/nysa11y/dialog-custom.css" %}
+    {% endset %}
+    {% set accordionLabel = "CSS" %}
+    {% set codeExpanded = false %}
+    {% set codeLanguage = "css" %}
+    {% include "partials/code-preview.njk" %}
+    {% endblock %}{# CSSCustom #}
+
+
+    {% block JSCustom %}
+    {% set code %}
+    {% include "../../../assets/nysa11y/dialog-custom.js" %}
+    {% endset %}
+    {% set accordionLabel = "JavaScript" %}
+    {% set codeExpanded = false %}
+    {% set codeLanguage = "js" %}
+    {% include "partials/code-preview.njk" %}
+    {% endblock %}{# JSCustom #}
+</div>
+{% endblock %}{# Alternatives #}
+
+{% block AboutThisPattern %}
+<p>
+    The dialog experience is a dramatic re-framing of users' context and
+focus, second only to a full page navigation. In fact, native operating
+system dialogs and early World Wide Web browser dialogs were actual new
+system or application windows displayed above the window of
+origination.
+</p>
+<p>
+    Subsequent to the late 1990s, most web browser dialogs were faked to
+visually appear like independent windows without actually being so. The
+ensuing years of inconsistency and poor accessibility led many user
+interface experts to <a href="https://www.nngroup.com/articles/modal-nonmodal-dialog/#toc-disadvantages-of-modal-dialogs-1" target="_blank">recommend caution</a> in the use of so-called dialogs. Even
+today, designers may reasonably consider <a
+href="https://modalzmodalzmodalz.com" target="_blank">different forms</a> of disclosure
+and navigation as alternative paradigms.
+</p>
+<p>
+    Decades of creative experimentation led to the addition of a <a
+href="https://html.spec.whatwg.org/dev/interactive-elements.html#the-dialog-element" target="_blank"><code class="element">dialog</code></a>
+element to the official HTML5 specification. This native element, which
+reached <a href="https://caniuse.com/?search=dialog" target="_blank">baseline browser
+support</a> in 2022, allows authors leeway to craft a range of user
+experiences. The HTML5 <code class="element">dialog</code> is the basis
+of the implementation shown here, and is the number one recommendation
+for any custom dialog development today. Though it is easier than ever
+to produce an accessible dialog, knowledge and care are still required
+to ensure this outcome. Let's deepen our understanding.
+</p>
+<h3 id="high-level-presentation">High level presentation</h3>
+<p>
+    A dialog is a real or apparent window that presents separately from
+the primary user interface surface.
+</p>
+<ul>
+  <li>Visually, dialogs appear in the foreground "above" the main
+  screen</li>
+  <li>Aurally, dialogs are perceived as discrete, self-contained
+  areas</li>
+  <li>A dialog may be automatically opened and closed by an operating
+  system or application, or manually activated by the user; manual control
+  is preferred</li>
+  <li>In the majority of cases, a user will interact with dialog content
+  in order to effect an outcome that closes the dialog and moves the user
+  to the primary surface</li>
+  <li>There is no set size for dialogs</li>
+  <li>It is possible, though not recommended, for dialogs to completely
+  fill a visual viewport by default; designers should account for cases in
+  which this is actually the best user experience, for example in screen
+  magnification and mobile portrait orientation scenarios</li>
+  <li>More commonly, dialogs are presented visually as relatively small
+  boxes centrally located on screen</li>
+</ul>
+<h3 id="what-is-a-modal">What is a "modal"?</h3>
+<p>A "modal" is an intensification of the dialog pattern.</p>
+<ul>
+  <li>Typically the primary content "below" a modal dialog is visually
+  dimmed to varying extents; with modals, non-dialog content should be
+  literally inert, unreachable, and non-interactive</li>
+  <li>Interaction with other application or operating system interfaces is
+  substantially blocked until required actions in the modal dialog are
+  complete</li>
+</ul>
+<h3 id="responsiveness">Responsiveness</h3>
+<p>
+    Like any content, a dialog should gracefully adapt to orientation
+change, mobile viewports, text size increase, and screen magnification.
+Design, test, and build for scenarios in which a dialog may fill an
+entire screen, may require scrollbars, and may accommodate a 200% font
+size increase.
+</p>
+<h3 id="focus-movement">Focus movement</h3>
+<p>
+    Whether it is visible or not, some page element always has
+programmatic focus, even if it happens to be the
+<code class="element">body</code>, which typically has focus on page
+load. Generally any element clicked by a mouse gains focus at that
+moment.
+</p>
+<p>
+    A proper modal dialog <strong>must</strong> pull focus into itself
+upon opening. It is essential that this happen, and likewise that while
+the dialog remains open focus be almost entirely trapped within. As seen
+on the Test page, in the majority of cases tabindex will remain inside
+the dialog, wrapping between the top and bottom of the dialog's user
+interface.
+</p>
+<p>
+    Let's consider a scenario in which a user activates a button in main
+content to open a modal dialog. The button interaction (whether by
+mouse, keyboard, voice command, or double-tap) sets focus on the button
+for a short period of time (miliseconds) until the dialog user interface
+is ready to gain focus. This button is the last element in main content
+to have focus and is the interaction trigger that spawns the dialog.
+Consequently when the dialog is closed, focus <strong>must</strong>
+return whence it came to this trigger button, provided the main user
+interface has not changed so dramatically that the button is no longer
+present. Failure to return focus from a dialog to its trigger is a
+severe and unfortunately common issue.
+</p>
+<p>
+    Usefully, authors may choose exactly where focus lands in a new
+dialog. While the various considerations are beyond the scope of this
+guide (see <a
+href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboardinteraction" target="_blank">Keyboard
+Interaction &rarr; Note</a> aside), one of the most effective techniques is
+to use the placement of focus to ensure the dialog's accessible name is
+immediately discovered.
+</p>
+<h3 id="an-accessible-name">An accessible name</h3>
+<p>
+    A dialog <strong>must</strong> identify itself clearly to all users
+upon opening. The best accessibility is one that works for everyone. A
+single label, title, or heading can serve all users equitably with
+minimal effort. In our example, a single <code class="element">H1</code>
+element is the visual, aural, and semantic label for the dialog by
+virtue of element choice, DOM placement, and attribute settings. In a
+browser's accessibility tree, the text content of this
+<code class="element">H1</code> is literally the <a
+href="https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/" target="_blank">accessible
+name</a> of the dialog.
+</p>
+<pre><code>&lt;dialog aria-labelledby=&quot;my-dialog-heading&quot;&gt;
+    &lt;h1 id=&quot;my-dialog-heading&quot; tabindex=&quot;-1&quot; autofocus&gt;My Dialog&lt;/h1&gt;
+&lt;/dialog&gt;</code></pre>
+<h3 id="traverse-and-close">Traverse and close</h3>
+<p>
+    Once inside a modal dialog, all content structure and interaction
+rules apply the same as on the primary surface; they are just contained
+within a (usually) smaller space. The key difference is in the
+conventions to uphold for dialog dismissal:
+</p>
+<ul>
+  <li>Activation of the <kbd>Escape</kbd> key <strong>must</strong> close
+  the dialog, <em>except</em> while the user interacts with a child
+  element that has its own response to <kbd>Escape</kbd>, for example, a
+  native HTML <code class="element">select</code>. However, not every user
+  has access to an <kbd>Escape</kbd> key.</li>
+  <li>
+      The founders of the Accessibility program at the BBC
+      <a href="https://a11yquest.com/pro/guides/patterns/modal-dialog/#accessible-controls" target="_blank">advise</a>:<br>
+      <q>
+          All modal dialogs <strong>must</strong> have a visible, accessible control within the dialog content, allowing the user to close the dialog; for example, a button labeled <em>Close</em> or a submit button for a dialog with a form. Do not assume that the user can press an <kbd>Escape</kbd> key or click outside the content area, for example.</q></li>
+</ul>
+<h3 id="best-quality-references">Best quality references</h3>
+<p>
+    This document describes and presents nearly the simplest possible modal dialog. Considerably more is possible and may be reasonably demanded by your particular set of users. When building upon our solid foundation, you may place confidence in these particular resources:
+</p>
+<ul>
+  <li><a href="https://a11yquest.com/pro/guides/patterns/modal-dialog/" target="_blank">Modal Dialog</a> from A11y Quest</li>
+  <li><a href="https://www.atomica11y.com/accessible-web/dialog-modal/" target="_blank">Dialog Modal HTML</a> and <a href="https://www.atomica11y.com/accessible-design/dialog-modal/" target="_blank">Dialog Modal Design</a> from Atomic Accessibility</li>
+  <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog" target="_blank">MDN HTML <code>dialog</code> element</a> from the Mozilla Developer Network</li>
+  <li><a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/" target="_blank">Dialog (Modal) Pattern</a> from the W3C ARIA Authoring Practices Guide</li>
+  <li><a href="https://html.spec.whatwg.org/dev/interactive-elements.html#the-dialog-element" target="_blank">The dialog element</a> from HTML: The Living Standard</li>
+</ul>
+
+{% endblock %}{# AboutThisPattern #}

--- a/src/content/components/modal/a11y-tests.njk
+++ b/src/content/components/modal/a11y-tests.njk
@@ -8,7 +8,9 @@ image_header: /assets/img/components/modal-header.svg
 stable: true
 parent: Modal
 navOrder: 1
-eleventyExcludeFromCollections: true
+extra_css:
+  - "/assets/nysa11y/checkbox-native.css"
+eleventyExcludeFromCollections: false
 ---
 
 <!-- Remove eleventyExcludeFromCollections to render page -->

--- a/src/content/components/modal/index.md
+++ b/src/content/components/modal/index.md
@@ -3,7 +3,7 @@ permalink: /components/modal/
 title: Modal
 description: Displays content in a dialog that appears over the page and requires user interaction before returning to the main content.
 image: /assets/img/components/modal.svg
-image_alt: An illustration of a modal.
+image_alt: An illustration of a modal dialog.
 image_header: /assets/img/components/modal-header.svg
 stable: true
 figma_link: https://www.figma.com/design/U2QpuSUXRTxbgG64Fzi9bu/%F0%9F%92%A0-NYS-Design-System?node-id=9962-6713&t=Fz3PChrCAbfpr60Y-4

--- a/src/content/components/modal/modal.11tydata.json5
+++ b/src/content/components/modal/modal.11tydata.json5
@@ -1,151 +1,355 @@
-/**
- * --------------------------------------------------------------------+
- * JSON5 supports comments and much more <https://json5.org/>          +
- * Values for `interactions.status` must be one of these combinations: +
- * ["passes", "success"] or ["fails", "error"] or ["to do", "warning"] +
- * Comment top-level members to prevent their corresponding njk blocks +
- * from rendering. Members that may be commented are exactly these:    +
- * tests, keyboard, mouse, screenReader, screenReaderMobile, voice,    +
- * zoom, disabilities.                                                 +
- * --------------------------------------------------------------------+
- */
 {
-  "pattern": "Modal",
+  "pattern": "Modal Dialog",
   "tests": {
-    "total": 0,
-    "pass": 0,
+    "total": 26,
+    "pass": 25,
     "fail": 0,
-    "toDo": 0
+    "toDo": 1
   },
-
   "keyboard": {
     "interactions": [
       {
-        "scenario": "WHEN I <kbd>k1<\/kbd>",
-        "requirements": ["THEN outcome k1"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN I use the <kbd>tab</kbd> key to move focus to a button programmed to launch a dialog, and use <kbd>spacebar</kbd> or <kbd>enter</kbd> key to activate the button",
+        "requirements": [
+          "THEN I see a dialog opens",
+          "THEN I see focus moves to a <em>landing point</em> either on the boundary of the dialog, or its heading, or a close-X button, or else the first focusable element in dialog content",
+          "THEN I see the page content behind the dialog appears dimmed",
+          "THEN I see the dialog has a heading to indicate its purpose",
+          "THEN I see there is at least one dialog <em>dismiss button</em> with a conventional label (such as <q>X</q>, <q>OK</q>, <q>Close</q>, <q>Cancel</q>, <q>Done</q>, or the like), or else sufficient instructions for workflow completion are provided"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       },
       {
-        "scenario": "WHEN I <kbd>k2<\/kbd>, <kbd>k3<\/kbd>",
-        "requirements": ["THEN outcome k1", "THEN outcome k2"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN focus is on the dialog landing point and I repeatedly activate <kbd>tab</kbd>",
+        "requirements": [
+          "THEN I see focus descends along the logical tabindex of interactive elements within the dialog",
+          "<mark>And if I <kbd>tab</kbd> past the last interactive element within the dialog</mark>",
+          "THEN I see focus returns to the first interactive element in the dialog and does <strong>not</strong> re-enter main page content"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN focus is on the dialog landing point and I repeatedly activate <kbd>shift</kbd> + <kbd>tab</kbd>",
+        "requirements": [
+          "THEN I see focus ascends along the logical tabindex of interactive elements within the dialog",
+          "<mark>And if I <kbd>shift</kbd> + <kbd>tab</kbd> past the first interactive element within the dialog</mark>",
+          "THEN I see focus returns to the last interactive element in the dialog and does <strong>not</strong> re-enter main page content"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "GIVEN the dialog contains an HTML <code class='element'>select</code> or any UI element that responds to the <kbd>escape</kbd> key; WHEN I <kbd>tab</kbd> to the element, open it with <kbd>spacebar</kbd> or <kbd>enter</kbd>, and activate <kbd>escape</kbd>",
+        "requirements": [
+          "THEN I see the UI component closes",
+          "THEN I see focus remains on the UI component",
+          "THEN I see the dialog remains and does <strong>not</strong> close"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN focus is within the dialog but <strong>not</strong> within an interactive element that responds to <kbd>escape</kbd>, and I activate <kbd>escape</kbd>",
+        "requirements": [
+          "THEN I see the dialog closes",
+          "THEN I see the main content is no longer dimmed",
+          "THEN I see focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN focus is on a dialog dismiss button and I activate it with <kbd>enter</kbd> or <kbd>spacebar</kbd>",
+        "requirements": [
+          "THEN I see the dialog closes",
+          "THEN I see the main content is no longer dimmed",
+          "THEN I see focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       }
     ]
   },
-
   "mouse": {
     "interactions": [
       {
-        "scenario": "WHEN I m4",
-        "requirements": ["THEN outcome m4"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN I click a button programmed to launch a dialog",
+        "requirements": [
+          "THEN I see a dialog opens",
+          "THEN I see focus moves to a <em>landing point</em> either on the boundary of the dialog, or its heading, or a close-X button, or else the first focusable element in dialog content",
+          "THEN I see the page content behind the dialog appears dimmed",
+          "THEN I see the dialog has a heading to indicate its purpose",
+          "THEN I see there is at least one dialog <em>dismiss button</em> with a conventional label (such as <q>X</q>, <q>OK</q>, <q>Close</q>, <q>Cancel</q>, <q>Done</q>, or the like), or else sufficient instructions for workflow completion are provided"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       },
       {
-        "scenario": "WHEN I m5, m6",
-        "requirements": ["THEN outcome m5", "THEN outcome m6"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN a dialog is open and I try to click elements behind the dialog in main page content",
+        "requirements": [
+          "THEN I see there is no action taken, nothing happens"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN a dialog is open and contains one or more dismiss buttons, and I click any of them",
+        "requirements": [
+          "THEN I see the dialog closes",
+          "THEN I see the main content is no longer dimmed",
+          "THEN I see focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN I use a mouse and I give focus to a dismiss button without activating it (mouse down, slide off, mouse up)",
+        "requirements": [
+          "THEN I see focus remains on the button",
+          "THEN I see the dialog remains and does <strong>not</strong> close"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       }
     ]
   },
-
   "screenReader": {
     "interactions": [
       {
-        "scenario": "WHEN I sr7",
-        "requirements": ["THEN outcome sr7"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN I move focus to a button programmed to launch a dialog, and use <kbd>spacebar</kbd> or <kbd>enter</kbd> key to activate the button",
+        "requirements": [
+          "THEN I hear a dialog announces itself as a dialog",
+          "THEN I hear the dialog announces its title or description"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       },
       {
-        "scenario": "WHEN I sr8, sr9",
-        "requirements": ["THEN outcome sr8", "THEN outcome sr9"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN I navigate both forward and back through dialog content by <kbd>arrow</kbd>, <kbd>tab</kbd>, link, form element, region, or any other idiomatic means",
+        "requirements": [
+          "THEN I hear that both focus and my cursor wrap around dialong content from end-to-end, are contained within the dialog, and do <strong>not</strong> re-enter main page content"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN I navigate through the entire dialog content",
+        "requirements": [
+          "THEN I hear there is at least one dialog <em>dismiss button</em> with a conventional label (such as <q>X</q>, <q>OK</q>, <q>Close</q>, <q>Cancel</q>, <q>Done</q>, or the like), or else sufficient instructions for workflow completion are provided"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "GIVEN the dialog contains an HTML <code class='element'>select</code> or any UI element that responds to the <kbd>escape</kbd> key; WHEN I navigate to the element, interactively enter it, and activate <kbd>escape</kbd>",
+        "requirements": [
+          "THEN I hear the UI component closes",
+          "THEN I hear focus remains on the UI component",
+          "THEN I do <strong>not</strong> hear the dialog closes",
+          "THEN minimal actions confirm that the dialog remains and did <strong>not</strong> close"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN focus is within the dialog but <strong>not</strong> within an interactive element that responds to <kbd>escape</kbd>, and I activate <kbd>escape</kbd>",
+        "requirements": [
+          "THEN I hear focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN focus is on a dialog dismiss button and I activate it with <kbd>enter</kbd> or <kbd>spacebar</kbd>",
+        "requirements": [
+          "THEN I hear focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       }
     ]
   },
-
   "screenReaderMobile": {
     "interactions": [
       {
-        "scenario": "WHEN I srm10",
-        "requirements": ["THEN outcome srm10"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN I swipe up or down to focus on a button programmed to launch a dialog and doubletap with the button in focus",
+        "requirements": [
+          "THEN I hear a dialog announces itself as a dialog",
+          "THEN I hear the dialog announces its title or description"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       },
       {
-        "scenario": "WHEN I srm11, srm12",
-        "requirements": ["THEN outcome srm11", "THEN outcome srm12"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN I explore the entire dialog content",
+        "requirements": [
+          "THEN I hear focus remains within the dialog and does <strong>not</strong> re-enter main page content",
+          "THEN I hear there is at least one dialog <em>dismiss button</em> with a conventional label (such as <q>X</q>, <q>OK</q>, <q>Close</q>, <q>Cancel</q>, <q>Done</q>, or the like), or else sufficient instructions for workflow completion are provided"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN I have a dismiss button in focus and doubletap",
+        "requirements": [
+          "THEN I hear focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       }
     ]
   },
-
   "voice": {
     "interactions": [
       {
-        "scenario": "WHEN I v13",
-        "requirements": ["THEN outcome v13"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN there is a button programmed to launch a dialog, and I activate the button by the command <q>Click <em>launch button label</em></q>",
+        "requirements": [
+          "THEN I see a dialog opens",
+          "THEN I see focus moves to a <em>landing point</em> either on the boundary of the dialog, or its heading, or a close-X button, or else the first focusable element in dialog content",
+          "THEN I see the page content behind the dialog appears dimmed",
+          "THEN I see the dialog has a heading to indicate its purpose",
+          "THEN I see there is at least one dialog <em>dismiss button</em> with a conventional label (such as <q>X</q>, <q>OK</q>, <q>Close</q>, <q>Cancel</q>, <q>Done</q>, or the like), or else sufficient instructions for workflow completion are provided"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       },
       {
-        "scenario": "WHEN I v14, v15",
-        "requirements": ["THEN outcome v14", "THEN outcome v15"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN a dialog is open and I command to click a button behind the dialog in main page content",
+        "requirements": [
+          "THEN I see there is no action taken, nothing happens"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN a dialog is open and contains a button with the label in the appearance of <q>X</q> and I command <q>Click close</q> or <q>Click dismiss</q> or <q>Click X</q>",
+        "requirements": [
+          "THEN I see at least one of these commands causes the dialog to close",
+          "THEN I see the main content is no longer dimmed",
+          "THEN I see focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN a dialog is open and I command <q>Press escape</q>",
+        "requirements": [
+          "THEN I see the dialog closes",
+          "THEN I see the main content is no longer dimmed",
+          "THEN I see focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
+      },
+      {
+        "scenario": "WHEN a dialog is open and contains one or more dismiss buttons, each with a <em>text label</em>, and I command <q>Click <em>text label</em></q>",
+        "requirements": [
+          "THEN I see the dialog closes",
+          "THEN I see the main content is no longer dimmed",
+          "THEN I see focus returns to the launch button"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       }
     ]
   },
-
   "zoom": {
     "interactions": [
       {
-        "scenario": "WHEN I z16",
-        "requirements": ["THEN outcome z16"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "WHEN the webpage is set to 400% zoom and a dialog is open",
+        "requirements": [
+          "THEN I see modal content is still visible"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       },
       {
-        "scenario": "WHEN I z17, z18",
-        "requirements": ["THEN outcome z17", "THEN outcome z18"],
-        "status": ["passes, fails, to do", "success, error, warning"]
+        "scenario": "TODO",
+        "requirements": [
+          "Refine this section"
+        ],
+        "status": [
+          "passes",
+          "success"
+        ]
       }
     ]
   },
-
   "disabilities": [
     {
       "type": "blindness",
       "criteria": [
         {
-          "description": "Blind 1...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.0 AA"
+          "description": "Name and role is documented",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#name-role-value",
+          "sc": "4.1.2 A"
         },
         {
-          "description": "Blind 2...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.1 AA"
+          "description": "Meets criteria across platforms, devices and viewports",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#principle4",
+          "sc": "Principle 4 - Robust"
         }
       ]
     },
     {
-      "type": "cognition",
+      "type": "cognitive",
       "criteria": [
         {
-          "description": "Cognition...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.2 AA"
-        }
-      ]
-    },
-    {
-      "type": "color",
-      "criteria": [
-        {
-          "description": "Color 1...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.3 AA"
-        },
-        {
-          "description": "Color 2...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.4 AA"
+          "description": "Users' adjustments to text spacing do not result in loss of content or functionality",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#text-spacing",
+          "sc": "1.4.12 AA"
         }
       ]
     },
@@ -153,14 +357,14 @@
       "type": "low vision",
       "criteria": [
         {
-          "description": "LowVis 1...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.5 AA"
+          "description": "Text can resize up to 200% with no loss of information",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#resize-text",
+          "sc": "1.4.4 AA"
         },
         {
-          "description": "LowVis 2...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.6 AA"
+          "description": "Text has a 4.5:1 minimum contrast ratio",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#contrast-minimum",
+          "sc": "1.4.3 AA"
         }
       ]
     },
@@ -168,14 +372,19 @@
       "type": "motor",
       "criteria": [
         {
-          "description": "Motor 1...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.8 AA"
+          "description": "Keyboard actions are documented",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#keyboard",
+          "sc": "2.1.1 A"
         },
         {
-          "description": "Motor 2...",
-          "uri": "https:\/\/www.w3.\/WAI\/WCAG22\/quickref\/#",
-          "sc": "0.0.9 AA"
+          "description": "The focus indication has a 3:1 minimum contrast ratio against default and adjacent elements",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#focus-appearance",
+          "sc": "2.4.13 AAA"
+        },
+        {
+          "description": "The focus indication has a minimum area equal to the width of the element and 2px in height",
+          "uri": "https://www.w3.org/WAI/WCAG22/quickref/#focus-appearance",
+          "sc": "2.4.13 AAA"
         }
       ]
     }

--- a/src/content/components/modal/modal.11tydata.json5
+++ b/src/content/components/modal/modal.11tydata.json5
@@ -1,5 +1,5 @@
 {
-  "pattern": "Modal Dialog",
+  "pattern": "Modal",
   "tests": {
     "total": 26,
     "pass": 25,


### PR DESCRIPTION
<mark>Creates new paths:</mark>

- `/components/modal/accessibility-build/`
- `/components/modal/accessibility-tests/`
- `/assets/nysa11y/dialog-native.css`
- `/assets/nysa11y/dialog-native.js`

<mark>Notes:</mark>

- This component has more than 25 tests
- Pure native `<dialog>` with `.showModal()`


closes: #455 